### PR TITLE
Add CI job to publish PyPI package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    environment:
+      name: pypi
+      url: https://pypi.org/p/openai-guardrails
+    permissions:
+      id-token: write # Important for trusted publishing to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: make sync
+      - name: Build package
+        run: uv build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request adds a new CI job to run PyPI package publishing operation using [Trusted Publisher feature](https://docs.pypi.org/trusted-publishers/). When we create a new release in this GitHub repo, this job will be triggered with the set release version.

@rm-openai for safety, can you quickly take a look at this configuration (I already did reviews by codex too though)? We've already created [the "pending" publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) for this new package.