### PR TITLE
Change the package name to openai-guardrails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "guardrails"
+name = "openai-guardrails"
 version = "0.1.0"
 description = "OpenAI Guardrails: A framework for building safe and reliable AI systems."
 readme = "README.md"

--- a/src/guardrails/__init__.py
+++ b/src/guardrails/__init__.py
@@ -66,7 +66,7 @@ __all__ = [
     "resources",  # resource modules
 ]
 
-__version__: str = _m.version("guardrails")
+__version__: str = _m.version("openai-guardrails")
 
 # Expose a package-level logger and install a NullHandler so importing the
 # library never configures global logging for the host application.


### PR DESCRIPTION
I ran `uv build --wheel` (or `python -m build --wheel`) and verified the generated package files. I found that the package name was not yet updated. This pull request resolves the issue.