### PR TITLE
Handle sync guardrail calls to avoid awaitable error

### DIFF
--- a/src/guardrails/checks/text/hallucination_detection.py
+++ b/src/guardrails/checks/text/hallucination_detection.py
@@ -52,10 +52,7 @@ from guardrails.registry import default_spec_registry
 from guardrails.spec import GuardrailSpecMetadata
 from guardrails.types import GuardrailLLMContextProto, GuardrailResult
 
-from .llm_base import (
-    LLMConfig,
-    LLMOutput,
-)
+from .llm_base import LLMConfig, LLMOutput, _invoke_openai_callable
 
 logger = logging.getLogger(__name__)
 
@@ -210,9 +207,10 @@ async def hallucination_detection(
         validation_query = f"{VALIDATION_PROMPT}\n\nText to validate:\n{candidate}"
 
         # Use the Responses API with file search and structured output
-        response = await ctx.guardrail_llm.responses.parse(
-            model=config.model,
+        response = await _invoke_openai_callable(
+            ctx.guardrail_llm.responses.parse,
             input=validation_query,
+            model=config.model,
             text_format=HallucinationDetectionOutput,
             tools=[{"type": "file_search", "vector_store_ids": [config.knowledge_source]}],
         )

--- a/src/guardrails/checks/text/prompt_injection_detection.py
+++ b/src/guardrails/checks/text/prompt_injection_detection.py
@@ -36,7 +36,7 @@ from guardrails.registry import default_spec_registry
 from guardrails.spec import GuardrailSpecMetadata
 from guardrails.types import GuardrailLLMContextProto, GuardrailResult
 
-from .llm_base import LLMConfig, LLMOutput
+from .llm_base import LLMConfig, LLMOutput, _invoke_openai_callable
 
 __all__ = ["prompt_injection_detection", "PromptInjectionDetectionOutput"]
 
@@ -341,9 +341,10 @@ def _create_skip_result(
 
 async def _call_prompt_injection_detection_llm(ctx: GuardrailLLMContextProto, prompt: str, config: LLMConfig) -> PromptInjectionDetectionOutput:
     """Call LLM for prompt injection detection analysis."""
-    parsed_response = await ctx.guardrail_llm.responses.parse(
-        model=config.model,
+    parsed_response = await _invoke_openai_callable(
+        ctx.guardrail_llm.responses.parse,
         input=prompt,
+        model=config.model,
         text_format=PromptInjectionDetectionOutput,
     )
 

--- a/tests/unit/checks/test_prompt_injection_detection.py
+++ b/tests/unit/checks/test_prompt_injection_detection.py
@@ -120,3 +120,21 @@ async def test_prompt_injection_detection_handles_analysis_error(monkeypatch: py
 
     assert result.tripwire_triggered is False  # noqa: S101
     assert "Error during prompt injection detection check" in result.info["observation"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_prompt_injection_detection_llm_supports_sync_responses() -> None:
+    """Underlying responses.parse may be synchronous for some clients."""
+    analysis = PromptInjectionDetectionOutput(flagged=True, confidence=0.4, observation="Action summary")
+
+    class _SyncResponses:
+        def parse(self, **kwargs: Any) -> Any:
+            _ = kwargs
+            return SimpleNamespace(output_parsed=analysis)
+
+    context = SimpleNamespace(guardrail_llm=SimpleNamespace(responses=_SyncResponses()))
+    config = LLMConfig(model="gpt-test", confidence_threshold=0.5)
+
+    parsed = await pid_module._call_prompt_injection_detection_llm(context, "prompt", config)
+
+    assert parsed is analysis  # noqa: S101


### PR DESCRIPTION
Fixes reported [bug](https://github.com/openai/openai-guardrails-python/issues/19) where using a sync client caused a `TypeError: object ChatCompletion can't be used in 'await' expression` error when LLM based guardrails are executed.
- Root cause was the guardrail LLM is initialized as the same class as the actual client and we run our guardrails asynchronously.
- Fix: Wrap sync methods with blocking callables in a background executor allowing all guardrails to continue to execute asynchronously

Changes:
- Helper method `_invoke_openai_callable` added to properly handle sync and async traffic from all api endpoints we support
- All LLM based checks now use the new helper
- Added unit tests to catch this in the future