### PR TITLE
Add GuardrailAgent prompt param support

### DIFF
--- a/src/guardrails/agents.py
+++ b/src/guardrails/agents.py
@@ -644,7 +644,7 @@ class GuardrailAgent:
         prompt_arg: Any | None = agent_kwargs.get("prompt")
         resolved_instructions = _resolve_agent_instructions(instructions, prompt_arg)
 
-        if resolved_instructions is None:
+        if resolved_instructions is None and prompt_arg is None:
             raise ValueError(
                 "GuardrailAgent requires either 'instructions' or 'prompt' to initialize the underlying Agent."
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ import sys
 import types
 from collections.abc import Iterator
 from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -54,11 +53,6 @@ class _DummyResponse:
     output_text: str | None = None
     type: str | None = None
     delta: str | None = None
-
-
-_GUARDRAILS_PACKAGE_STUB = types.ModuleType("guardrails")
-_GUARDRAILS_PACKAGE_STUB.__path__ = [str(Path(__file__).resolve().parents[1] / "src" / "guardrails")]
-sys.modules.setdefault("guardrails", _GUARDRAILS_PACKAGE_STUB)
 
 
 _STUB_OPENAI_MODULE = types.ModuleType("openai")

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -6,13 +6,18 @@ import sys
 import types
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
-from guardrails._openai_utils import SAFETY_IDENTIFIER_HEADER, SAFETY_IDENTIFIER_VALUE
-from guardrails.types import GuardrailResult
+guardrails_pkg = types.ModuleType("guardrails")
+guardrails_pkg.__path__ = [str(Path(__file__).resolve().parents[2] / "src" / "guardrails")]
+sys.modules.setdefault("guardrails", guardrails_pkg)
+
+from guardrails._openai_utils import SAFETY_IDENTIFIER_HEADER, SAFETY_IDENTIFIER_VALUE  # noqa: E402
+from guardrails.types import GuardrailResult  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Stub agents SDK module so guardrails.agents can import required symbols.


### PR DESCRIPTION
Via bug report:

One minor thing, it seems like your Guardrail Agent isn't a 1:1 drop in for the Agents SDK, using a remote prompt gives me an error.

```
TypeError: GuardrailAgent.__new__() missing 1 required positional argument: 'instructions'
```