### PR TITLE
Correctly passing API key to moderation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,12 @@ class APITimeoutError(Exception):
 class NotFoundError(Exception):
     """Stub 404 not found error."""
 
+    def __init__(self, message: str, *, response: Any = None, body: Any = None) -> None:
+        """Initialize NotFoundError with OpenAI-compatible signature."""
+        super().__init__(message)
+        self.response = response
+        self.body = body
+
 
 _STUB_OPENAI_MODULE.APITimeoutError = APITimeoutError
 _STUB_OPENAI_MODULE.NotFoundError = NotFoundError


### PR DESCRIPTION
Fixes this reported [BUG](https://github.com/openai/openai-guardrails-python/issues/31): 
- `api_key` passed in via client initialization is not properly passed to `moderation` check

The fix:
- Default to using the `guardrail_llm`, if the moderation endpoint does not exist with that client, fall back to creating a compatible OpenAI client via `env variable`
- Documentation already mentions how an `OpenAI API key` is required for the Moderation check
- Added tests

Future PR to allow configuring an `api_key` specific to the moderation check via the config file (will only be needed for users who are using non-openai models as their base client).