### PR TITLE
Pin thinc>=8.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "openai-agents>=0.3.3",
     "pip>=25.0.1",
     "presidio-analyzer>=2.2.360",
+    "thinc>=8.3.6",
 ]
 classifiers = [
   "Typing :: Typed",


### PR DESCRIPTION
Pinned `thinc >=8.3.6` requirement to avoid `Cython` conflicts with `thinc==8.3.4`