### PR TITLE
Update HallucinationDetectionOutput in line with documentation

### DIFF
--- a/src/guardrails/checks/text/hallucination_detection.py
+++ b/src/guardrails/checks/text/hallucination_detection.py
@@ -94,11 +94,30 @@ class HallucinationDetectionOutput(LLMOutput):
     Extends the base LLM output with hallucination-specific details.
 
     Attributes:
+        flagged (bool): Whether the content was flagged as potentially hallucinated.
+        confidence (float): Confidence score (0.0 to 1.0) that the input is hallucinated.
+        reasoning (str): Detailed explanation of the analysis.
         hallucination_type (str | None): Type of hallucination detected.
-        hallucinated_statements (list[str] | None): Specific statements flagged as potentially hallucinated.
-        verified_statements (list[str] | None): Specific statements that are supported by the documents.
+        hallucinated_statements (list[str] | None): Specific statements flagged as
+            potentially hallucinated.
+        verified_statements (list[str] | None): Specific statements that are supported
+            by the documents.
     """
 
+    flagged: bool = Field(
+        ...,
+        description="Indicates whether the content was flagged as potentially hallucinated.",
+    )
+    confidence: float = Field(
+        ...,
+        description="Confidence score (0.0 to 1.0) that the input is hallucinated.",
+        ge=0.0,
+        le=1.0,
+    )
+    reasoning: str = Field(
+        ...,
+        description="Detailed explanation of the hallucination analysis.",
+    )
     hallucination_type: str | None = Field(
         None,
         description="Type of hallucination detected (e.g., 'factual_error', 'unsupported_claim').",


### PR DESCRIPTION
The definition of the output schema is not consistent with the typescript library:
https://github.com/openai/openai-guardrails-js/blob/a8e8ace55601a9e3f383891862de6100751d2e8c/src/checks/hallucination-detection.ts#L55-L71 
or the documentation at 
https://openai.github.io/openai-guardrails-python/ref/checks/hallucination_detection/#what-it-returns 

Notably it's missing the `reasoning` field, so although the model can respond with that, it's not returned in the structured output available to the caller.

Testing:
Before
<img width="886" height="230" alt="image" src="https://github.com/user-attachments/assets/7a00491b-22bc-4f6e-a26e-e846fb3198f4" />

After
<img width="889" height="358" alt="image" src="https://github.com/user-attachments/assets/cd5f4d9f-0d18-4991-8c28-4611fa354a4a" />
