### PR TITLE
fix: useStrEnum for moderation and PII enums

### DIFF
--- a/src/guardrails/_base_client.py
+++ b/src/guardrails/_base_client.py
@@ -47,6 +47,7 @@ def _warn_llm_response_deprecation(instance: Any) -> None:
         )
         _warned_instance_ids[instance_id] = instance
 
+
 # Type alias for OpenAI response types
 OpenAIResponseType = Union[Completion, ChatCompletion, ChatCompletionChunk, Response]  # noqa: UP007
 

--- a/src/guardrails/checks/text/llm_base.py
+++ b/src/guardrails/checks/text/llm_base.py
@@ -110,10 +110,7 @@ class LLMConfig(BaseModel):
     )
     include_reasoning: bool = Field(
         False,
-        description=(
-            "Include reasoning/explanation fields in output. "
-            "Defaults to False for token efficiency. Enable for development/debugging."
-        ),
+        description=("Include reasoning/explanation fields in output. Defaults to False for token efficiency. Enable for development/debugging."),
     )
 
     model_config = ConfigDict(extra="forbid")

--- a/src/guardrails/checks/text/moderation.py
+++ b/src/guardrails/checks/text/moderation.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from enum import Enum
+from enum import StrEnum
 from functools import cache
 from typing import Any
 
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["moderation", "Category", "ModerationCfg"]
 
 
-class Category(str, Enum):
+class Category(StrEnum):
     """Enumeration of supported moderation categories.
 
     These categories correspond to types of harmful or restricted content

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -81,7 +81,7 @@ import urllib.parse
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Final
 
 from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer, RecognizerRegistry, RecognizerResult
@@ -230,7 +230,7 @@ def _get_analyzer_engine() -> AnalyzerEngine:
     return engine
 
 
-class PIIEntity(str, Enum):
+class PIIEntity(StrEnum):
     """Supported PII entity types for detection.
 
     Includes global and region-specific types (US, UK, Spain, Italy, etc.).

--- a/src/guardrails/checks/text/prompt_injection_detection.py
+++ b/src/guardrails/checks/text/prompt_injection_detection.py
@@ -301,9 +301,7 @@ Previous context:
             user_goal_text = user_intent_dict["most_recent_message"]
 
         # Build prompt with appropriate output format based on include_reasoning
-        output_format_instruction = (
-            PROMPT_INJECTION_REASONING_OUTPUT if config.include_reasoning else PROMPT_INJECTION_BASE_OUTPUT
-        )
+        output_format_instruction = PROMPT_INJECTION_REASONING_OUTPUT if config.include_reasoning else PROMPT_INJECTION_BASE_OUTPUT
 
         # Format for LLM analysis
         analysis_prompt = f"""{PROMPT_INJECTION_DETECTION_CHECK_PROMPT}

--- a/tests/unit/checks/test_hallucination_detection.py
+++ b/tests/unit/checks/test_hallucination_detection.py
@@ -135,4 +135,3 @@ async def test_hallucination_detection_requires_valid_vector_store() -> None:
 
     with pytest.raises(ValueError, match="knowledge_source must be a valid vector store ID starting with 'vs_'"):
         await hallucination_detection(context, "Test", config_empty)
-

--- a/tests/unit/checks/test_llm_base.py
+++ b/tests/unit/checks/test_llm_base.py
@@ -273,9 +273,7 @@ def test_build_analysis_payload_formats_correctly() -> None:
 
 def test_build_analysis_payload_trims_to_max_turns() -> None:
     """_build_analysis_payload should trim conversation to max_turns."""
-    conversation_history = [
-        {"role": "user", "content": f"Message {i}"} for i in range(15)
-    ]
+    conversation_history = [{"role": "user", "content": f"Message {i}"} for i in range(15)]
 
     payload_str = _build_analysis_payload(conversation_history, "latest", max_turns=5)
     payload = json.loads(payload_str)

--- a/tests/unit/checks/test_prompt_injection_detection.py
+++ b/tests/unit/checks/test_prompt_injection_detection.py
@@ -90,9 +90,7 @@ def test_extract_user_intent_from_messages_handles_multiple_user_messages() -> N
 
 def test_extract_user_intent_respects_max_turns() -> None:
     """User intent extraction limits context to max_turns user messages."""
-    messages = [
-        {"role": "user", "content": f"User message {i}"} for i in range(10)
-    ]
+    messages = [{"role": "user", "content": f"User message {i}"} for i in range(10)]
 
     # With max_turns=3, should keep only the last 3 user messages
     result = _extract_user_intent_from_messages(messages, max_turns=3)
@@ -103,9 +101,7 @@ def test_extract_user_intent_respects_max_turns() -> None:
 
 def test_extract_user_intent_max_turns_default_is_ten() -> None:
     """Default max_turns should be 10."""
-    messages = [
-        {"role": "user", "content": f"User message {i}"} for i in range(15)
-    ]
+    messages = [{"role": "user", "content": f"User message {i}"} for i in range(15)]
 
     result = _extract_user_intent_from_messages(messages)
 
@@ -549,7 +545,7 @@ async def test_prompt_injection_detection_includes_reasoning_when_enabled(
     """When include_reasoning=True, output should include observation and evidence fields."""
     history = [
         {"role": "user", "content": "Get my password"},
-        {"type": "function_call", "tool_name": "steal_credentials", "arguments": '{}', "call_id": "c1"},
+        {"type": "function_call", "tool_name": "steal_credentials", "arguments": "{}", "call_id": "c1"},
     ]
     context = _FakeContext(history)
 

--- a/tests/unit/test_response_flattening.py
+++ b/tests/unit/test_response_flattening.py
@@ -219,6 +219,7 @@ def test_nested_attribute_access_works() -> None:
 
 def test_property_access_works() -> None:
     """Test that property access on delegated objects works correctly."""
+
     # Create a mock with a property
     class MockResponse:
         @property
@@ -412,4 +413,3 @@ def test_dir_includes_delegated_attributes() -> None:
     response_attrs = set(attrs)
     # All llm_response attributes should be in response's dir()
     assert llm_attrs.issubset(response_attrs)  # noqa: S101
-


### PR DESCRIPTION
## Summary

Replace the `Category` and `PIIEntity` enums with `enum.StrEnum` to satisfy Ruff `UP042` and align with Python 3.11+ best practices.

## Why

This repository requires Python 3.11+, where `StrEnum` is available and preferred over inheriting from both `str` and `Enum`.

Ruff now reports `UP042` for these enum definitions:

- `src/guardrails/checks/text/moderation.py`
- `src/guardrails/checks/text/pii.py`

## Changes

- Replaced `class Category(str, Enum)` with `class Category(StrEnum)`
- Replaced `class PIIEntity(str, Enum)` with `class PIIEntity(StrEnum)`
- Updated the corresponding imports from `Enum` to `StrEnum`

## Compatibility Notes

This change is low risk for the current codebase because the affected paths use enum `.value` where string values are required. One behavior difference is that `str(member)` and formatted string output now produce the raw enum value instead of `EnumName.MEMBER`. No affected internal usage was found in the current codebase, but this is the reason Ruff treats the fix as unsafe.
