### PR TITLE
Let GuardrailAgent use a custom AsyncOpenAI client for guardrail checks

### DIFF
--- a/src/guardrails/agents.py
+++ b/src/guardrails/agents.py
@@ -16,7 +16,10 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
 
 from .types import GuardrailResult
 from .utils.conversation import merge_conversation_with_items, normalize_conversation
@@ -159,15 +162,23 @@ def _attach_guardrail_to_tools(tools: list[Any], guardrail: Callable, guardrail_
         getattr(tool, attr_name).append(guardrail)
 
 
-def _create_default_tool_context() -> Any:
-    """Create a default context for tool guardrails."""
+def _create_default_tool_context(guardrail_llm: AsyncOpenAI | None = None) -> Any:
+    """Create a default context for tool guardrails.
+
+    Args:
+        guardrail_llm: Optional pre-configured AsyncOpenAI client used to run tool-level
+            guardrails. When omitted, a default ``AsyncOpenAI()`` is created (which honors
+            the standard ``OPENAI_*`` environment variables). Pass a client built with a
+            custom ``base_url``/``api_key`` to route guardrail checks through a proxy such
+            as LiteLLM.
+    """
     from openai import AsyncOpenAI
 
     @dataclass
     class DefaultContext:
         guardrail_llm: AsyncOpenAI
 
-    return DefaultContext(guardrail_llm=AsyncOpenAI())
+    return DefaultContext(guardrail_llm=guardrail_llm or AsyncOpenAI())
 
 
 def _create_conversation_context(
@@ -607,6 +618,7 @@ class GuardrailAgent:
         instructions: str | Callable[[Any, Any], Any] | None = None,
         raise_guardrail_errors: bool = False,
         block_on_tool_violations: bool = False,
+        guardrail_llm: AsyncOpenAI | None = None,
         **agent_kwargs: Any,
     ) -> Any:  # Returns agents.Agent
         """Create a new Agent instance with guardrails automatically configured.
@@ -631,6 +643,12 @@ class GuardrailAgent:
             block_on_tool_violations: If True, tool guardrail violations raise exceptions (halt execution).
                 If False (default), violations use reject_content (agent can continue and explain).
                 Note: Agent-level input/output guardrails always block regardless of this setting.
+            guardrail_llm: Optional pre-configured AsyncOpenAI client used to run tool-level
+                guardrails (e.g. Prompt Injection Detection). When omitted, a default
+                ``AsyncOpenAI()`` is used, which honors the standard ``OPENAI_*`` environment
+                variables. Pass a client built with a custom ``base_url``/``api_key`` to route
+                guardrail checks through a proxy such as LiteLLM, mirroring how
+                ``GuardrailsAsyncOpenAI`` forwards client configuration to its guardrail client.
             **agent_kwargs: All other arguments passed to Agent constructor (including tools)
 
         Returns:
@@ -671,6 +689,12 @@ class GuardrailAgent:
         user_input_guardrails = agent_kwargs.pop("input_guardrails", [])
         user_output_guardrails = agent_kwargs.pop("output_guardrails", [])
 
+        # Build a single guardrail-execution context so that every guardrail (agent-level and
+        # tool-level) shares the same AsyncOpenAI client. When the caller supplies a custom
+        # guardrail_llm (e.g. one pointing at a LiteLLM proxy), all guardrail checks honor it;
+        # otherwise this falls back to a default AsyncOpenAI() that reads OPENAI_* env vars.
+        guardrail_context = _create_default_tool_context(guardrail_llm)
+
         # Create agent-level INPUT guardrails from config
         input_guardrails = []
 
@@ -687,6 +711,7 @@ class GuardrailAgent:
                     config=config,
                     stages=agent_input_stages,
                     guardrail_type="input",
+                    context=guardrail_context,
                     raise_guardrail_errors=raise_guardrail_errors,
                 )
             )
@@ -701,6 +726,7 @@ class GuardrailAgent:
                 config=config,
                 stages=["output"],
                 guardrail_type="output",
+                context=guardrail_context,
                 raise_guardrail_errors=raise_guardrail_errors,
             )
 
@@ -714,7 +740,7 @@ class GuardrailAgent:
         # - pre_flight + input stages → tool_input_guardrail (checks BEFORE tool execution)
         # - output stage → tool_output_guardrail (checks AFTER tool execution)
         if tools and (preflight_tool or input_tool or output_tool):
-            context = _create_default_tool_context()
+            context = guardrail_context
 
             # pre_flight + input stages → tool_input_guardrail
             for guardrail in preflight_tool + input_tool:

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -246,6 +246,15 @@ def test_create_default_tool_context_provides_async_client(monkeypatch: pytest.M
     assert isinstance(context.guardrail_llm, StubAsyncOpenAI)  # noqa: S101
 
 
+def test_create_default_tool_context_uses_provided_client() -> None:
+    """A caller-supplied guardrail_llm should be used verbatim, without constructing a new client."""
+    sentinel = SimpleNamespace(base_url="https://proxy.example/v1")
+
+    context = agents._create_default_tool_context(sentinel)
+
+    assert context.guardrail_llm is sentinel  # noqa: S101
+
+
 def test_attach_guardrail_to_tools_initializes_lists() -> None:
     """Attaching guardrails should create input/output lists when missing."""
     tool = SimpleNamespace()
@@ -588,6 +597,44 @@ def test_guardrail_agent_attaches_tool_guardrails(monkeypatch: pytest.MonkeyPatc
     assert len(tool.tool_input_guardrails) == 1  # type: ignore[attr-defined]  # noqa: S101
     # Agent-level guardrails should be attached (one for Sensitive Data Check)
     assert len(agent_instance.input_guardrails or []) >= 1  # noqa: S101
+
+
+def test_guardrail_agent_forwards_custom_guardrail_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A custom guardrail_llm should be threaded into the shared guardrail context."""
+    tool_guard = _make_guardrail("Prompt Injection Detection")
+
+    pipeline = SimpleNamespace(
+        pre_flight=SimpleNamespace(),
+        input=SimpleNamespace(),
+        output=SimpleNamespace(),
+    )
+
+    def fake_instantiate_guardrails(stage: Any, registry: Any | None = None) -> list[Any]:
+        return [tool_guard] if stage is pipeline.pre_flight else []
+
+    monkeypatch.setattr(runtime_module, "load_pipeline_bundles", lambda config: pipeline, raising=False)
+    monkeypatch.setattr(runtime_module, "instantiate_guardrails", fake_instantiate_guardrails, raising=False)
+
+    captured: list[Any] = []
+    real_create = agents._create_default_tool_context
+
+    def spy_create(guardrail_llm: Any = None) -> Any:
+        captured.append(guardrail_llm)
+        return real_create(guardrail_llm)
+
+    monkeypatch.setattr(agents, "_create_default_tool_context", spy_create)
+
+    custom_client = SimpleNamespace(base_url="https://proxy.example/v1")
+    tool = SimpleNamespace()
+    agents.GuardrailAgent(
+        config={"version": 1},
+        name="Proxy Agent",
+        instructions="Help users.",
+        tools=[tool],
+        guardrail_llm=custom_client,
+    )
+
+    assert captured == [custom_client]  # noqa: S101
 
 
 def test_guardrail_agent_without_tools(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Fixes #70.

## Problem

`GuardrailsAsyncOpenAI` forwards `base_url`, `api_key`, `organization`, `timeout`, `max_retries` and `default_headers` to the separate client it builds for guardrail checks (`client.py`, `_create_default_context`). `GuardrailAgent` has no equivalent path: the context it builds for tool-level guardrails comes from a bare `AsyncOpenAI()` in `_create_default_tool_context()`, and the agent-level path constructs another bare `AsyncOpenAI()` inline.

As #70 notes, that means a programmatically configured `base_url` (for example a LiteLLM proxy) is ignored when guardrails run under `GuardrailAgent`. Only the `OPENAI_*` environment variables are picked up, because that is all a bare `AsyncOpenAI()` reads.

## Fix

Add an optional `guardrail_llm: AsyncOpenAI | None` parameter to `GuardrailAgent`. Inside the factory, build a single guardrail-execution context from it and reuse that context for both agent-level guardrails (passed through the existing `context` argument of `_create_agents_guardrails_from_config`) and tool-level guardrails. This also removes the duplicate default-context construction so every guardrail in an agent shares one client.

When `guardrail_llm` is omitted the behavior is unchanged: a default `AsyncOpenAI()` is used. The mechanism mirrors how the existing checks already consume `ctx.guardrail_llm`, so callers can point guardrails at a proxy:

```python
from openai import AsyncOpenAI
from guardrails import GuardrailAgent

proxy = AsyncOpenAI(base_url="http://localhost:4000", api_key="sk-...")
agent = GuardrailAgent(
    config="guardrails_config.json",
    name="Assistant",
    tools=[...],
    guardrail_llm=proxy,
)
```

## Testing

- Added `test_create_default_tool_context_uses_provided_client` and `test_guardrail_agent_forwards_custom_guardrail_llm`.
- `make lint` passes; the full unit suite is green (`test_agents.py` 47 passed; 425 passed across `tests/unit` with the optional eval extra not installed locally). No behavior change when the new parameter is unset.
