### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "openai-agents>=0.3.3",
     "pip>=25.0.1",
     "presidio-analyzer>=2.2.360",
-    "thinc>=8.3.6",
+    "thinc>=8.3.12,<8.4.0",
 ]
 classifiers = [
   "Typing :: Typed",
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Intended Audience :: Developers",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary

Fixes #78.

Presidio now publishes Python 3.14-compatible packages, but installing `openai-guardrails==0.2.1` on Python 3.14 can still resolve `thinc>=8.3.6` toward `thinc` 9.x.

This keeps the direct `thinc` dependency on the SpaCy 3.8-compatible line, adds the Python 3.14 classifier, and runs CI on Python 3.14.

## Testing

- Python 3.11: sync, ruff, pytest `433 passed`
- Python 3.12: sync, ruff, pytest `433 passed`
- Python 3.13: sync, ruff, pytest `433 passed`
- Python 3.14: sync, ruff, pytest `433 passed`
- `git diff --check`
- metadata parse check for dependency, classifier, and CI matrix
