### PR TITLE
Remove the runtime pip dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,10 @@ jobs:
             pyproject.toml
 
       - name: Install dependencies
-        run: make sync
+        run: |
+          make sync
+          uv pip install --python .venv/bin/python \
+            https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 
       - name: Lint with ruff
         run: make lint

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ python -m spacy download en_core_web_sm
 uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 ```
 
+Contains PII validates and loads this model during client initialization, so an absent or unloadable model fails configuration before any request.
+
 ### Usage
 
 Follow the configuration and installation instructions at [guardrails.openai.com](https://guardrails.openai.com/).

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ You can download [openai-guardrails package](https://pypi.org/project/openai-gua
 pip install openai-guardrails
 ```
 
+If you enable Contains PII, install its spaCy model while building or deploying the application:
+
+```bash
+# With pip
+python -m spacy download en_core_web_sm
+
+# With uv and spaCy 3.8
+uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+```
+
 ### Usage
 
 Follow the configuration and installation instructions at [guardrails.openai.com](https://guardrails.openai.com/).
@@ -30,6 +40,7 @@ cd openai-guardrails-python
 # Install the package (editable), plus example extras if desired
 pip install -e .
 pip install -e ".[examples]"
+pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 ```
 
 ## Integration Details
@@ -171,6 +182,7 @@ The package includes examples in the [`examples/` directory](./examples):
 ```bash
 pip install -e .
 pip install "openai-guardrails[examples]"
+pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 ```
 
 #### Run

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,6 +18,8 @@ python -m spacy download en_core_web_sm
 uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 ```
 
+Contains PII validates and loads this model during client initialization, so an absent or unloadable model fails configuration before any request.
+
 ## Set API Key
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,6 +8,16 @@ Get started with Guardrails in minutes. Guardrails provides drop-in replacements
 pip install openai-guardrails
 ```
 
+If you enable Contains PII, install its spaCy model while building or deploying the application:
+
+```bash
+# With pip
+python -m spacy download en_core_web_sm
+
+# With uv and spaCy 3.8
+uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+```
+
 ## Set API Key
 
 ```bash

--- a/docs/ref/checks/pii.md
+++ b/docs/ref/checks/pii.md
@@ -12,6 +12,8 @@ python -m spacy download en_core_web_sm
 uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 ```
 
+Contains PII validates and loads this model during client initialization, so an absent or unloadable model fails configuration before any request.
+
 **Advanced Security Features:**
 
 - **Unicode normalization**: Prevents bypasses using fullwidth characters (＠) or zero-width spaces

--- a/docs/ref/checks/pii.md
+++ b/docs/ref/checks/pii.md
@@ -2,6 +2,16 @@
 
 Detects personally identifiable information (PII) such as SSNs, phone numbers, credit card numbers, and email addresses using Microsoft's [Presidio library](https://microsoft.github.io/presidio/). Will automatically mask detected PII or block content based on configuration.
 
+Install the required small English spaCy model when building or deploying the application:
+
+```bash
+# With pip
+python -m spacy download en_core_web_sm
+
+# With uv and spaCy 3.8
+uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+```
+
 **Advanced Security Features:**
 
 - **Unicode normalization**: Prevents bypasses using fullwidth characters (＠) or zero-width spaces

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "openai>=1.75.0",
     "pydantic>=2.11.3",
     "openai-agents>=0.3.3",
-    "pip>=25.0.1",
     "presidio-analyzer>=2.2.360",
     "thinc>=8.3.6",
 ]

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -124,6 +124,9 @@ def _get_analyzer_engine() -> AnalyzerEngine:
     Returns:
         AnalyzerEngine: Analyzer configured with English NLP support and
         region-specific recognizers backed by Presidio.
+
+    Raises:
+        RuntimeError: If the en_core_web_sm spaCy model is unavailable.
     """
     if not spacy.util.is_package("en_core_web_sm") and not Path("en_core_web_sm").exists():
         raise RuntimeError(

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -348,6 +348,18 @@ class PIIConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize the PII analyzer while the guardrail is configured.
+
+        Args:
+            __context (Any): Pydantic initialization context.
+
+        Raises:
+            RuntimeError: If the required spaCy model is unavailable.
+            OSError: If a provisioned spaCy model cannot be loaded.
+        """
+        _get_analyzer_engine()
+
 
 @dataclass(frozen=True, slots=True)
 class PiiDetectionResult:

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -82,8 +82,10 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from pathlib import Path
 from typing import Any, Final
 
+import spacy
 from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer, RecognizerRegistry, RecognizerResult
 from presidio_analyzer.nlp_engine import NlpEngineProvider
 from presidio_analyzer.predefined_recognizers.country_specific.korea.kr_rrn_recognizer import (
@@ -123,6 +125,12 @@ def _get_analyzer_engine() -> AnalyzerEngine:
         AnalyzerEngine: Analyzer configured with English NLP support and
         region-specific recognizers backed by Presidio.
     """
+    if not spacy.util.is_package("en_core_web_sm") and not Path("en_core_web_sm").exists():
+        raise RuntimeError(
+            "The 'en_core_web_sm' spaCy model is required by the Contains PII guardrail. "
+            "Provision a compatible en_core_web_sm model during deployment."
+        )
+
     nlp_config: Final[dict[str, Any]] = {
         "nlp_engine_name": "spacy",
         "models": [

--- a/src/guardrails/checks/text/secret_keys.py
+++ b/src/guardrails/checks/text/secret_keys.py
@@ -40,12 +40,10 @@ Examples:
 
 from __future__ import annotations
 
-import functools
 import math
 import re
 from typing import Any, TypedDict
 
-from presidio_analyzer import AnalyzerEngine, Pattern, PatternRecognizer
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from guardrails.registry import default_spec_registry
@@ -153,28 +151,6 @@ CONFIGS: dict[str, SecretCfg] = {
         "strict_mode": False,
     },
 }
-
-
-@functools.lru_cache(maxsize=1)
-def _get_analyzer_engine() -> AnalyzerEngine:
-    """Return a singleton, configured Presidio AnalyzerEngine for pattern detection.
-
-    Includes a recognizer for file extensions to allow filtering in non-strict mode.
-
-    Returns:
-        AnalyzerEngine: Initialized Presidio analyzer engine.
-    """
-    engine = AnalyzerEngine()
-
-    # Recognise file extensions so we can filter them out in non‑strict mode.
-    pattern = Pattern(
-        name="file_extension",
-        regex=f"\\S+({'|'.join(re.escape(ext) for ext in ALLOWED_EXTENSIONS)})",
-        score=1.0,
-    )
-    engine.registry.add_recognizer(PatternRecognizer(supported_entity="FILE_EXTENSION", patterns=[pattern]))
-
-    return engine
 
 
 class SecretKeysCfg(BaseModel):

--- a/tests/unit/checks/test_pii.py
+++ b/tests/unit/checks/test_pii.py
@@ -6,10 +6,41 @@ masking behavior, and blocking behavior for various entity types.
 
 from __future__ import annotations
 
-import pytest
+from pathlib import Path
+from unittest.mock import Mock
 
-from guardrails.checks.text.pii import PIIConfig, PIIEntity, _normalize_unicode, pii
+import pytest
+import spacy
+
+from guardrails.checks.text.pii import PIIConfig, PIIEntity, _get_analyzer_engine, _normalize_unicode, pii
 from guardrails.types import GuardrailResult
+
+
+def test_missing_spacy_model_fails_without_starting_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A missing PII model should fail before Presidio can invoke spaCy or pip."""
+    download = Mock()
+    subprocess_run = Mock()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(spacy.util, "is_package", lambda _: False)
+    monkeypatch.setattr(spacy.cli, "download", download)
+    monkeypatch.setattr("subprocess.run", subprocess_run)
+    _get_analyzer_engine.cache_clear()
+
+    with pytest.raises(RuntimeError, match="Provision a compatible en_core_web_sm model during deployment"):
+        _get_analyzer_engine()
+
+    download.assert_not_called()
+    subprocess_run.assert_not_called()
+
+
+def test_local_spacy_model_is_supported(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Presidio accepts a provisioned local model directory as well as a wheel."""
+    spacy.load("en_core_web_sm").to_disk(tmp_path / "en_core_web_sm")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(spacy.util, "is_package", lambda _: False)
+    _get_analyzer_engine.cache_clear()
+
+    _get_analyzer_engine()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/checks/test_pii.py
+++ b/tests/unit/checks/test_pii.py
@@ -13,21 +13,39 @@ import pytest
 import spacy
 
 from guardrails.checks.text.pii import PIIConfig, PIIEntity, _get_analyzer_engine, _normalize_unicode, pii
+from guardrails.exceptions import ConfigError
+from guardrails.runtime import ConfigBundle, GuardrailConfig, instantiate_guardrails
 from guardrails.types import GuardrailResult
 
 
-def test_missing_spacy_model_fails_without_starting_download(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """A missing PII model should fail before Presidio can invoke spaCy or pip."""
+@pytest.mark.parametrize(
+    ("corrupt_local_model", "error"),
+    [
+        (False, "Provision a compatible en_core_web_sm model during deployment"),
+        (True, None),
+    ],
+    ids=["missing", "corrupt-local-path"],
+)
+def test_invalid_spacy_model_fails_configuration_without_starting_download(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    corrupt_local_model: bool,
+    error: str | None,
+) -> None:
+    """An unavailable PII model should fail configuration before any request or installer call."""
     download = Mock()
     subprocess_run = Mock()
+    if corrupt_local_model:
+        (tmp_path / "en_core_web_sm").mkdir()
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(spacy.util, "is_package", lambda _: False)
-    monkeypatch.setattr(spacy.cli, "download", download)
+    monkeypatch.setattr("spacy.cli.download", download)
     monkeypatch.setattr("subprocess.run", subprocess_run)
     _get_analyzer_engine.cache_clear()
 
-    with pytest.raises(RuntimeError, match="Provision a compatible en_core_web_sm model during deployment"):
-        _get_analyzer_engine()
+    bundle = ConfigBundle(guardrails=[GuardrailConfig(name="Contains PII", config={"entities": ["EMAIL_ADDRESS"]})])
+    with pytest.raises(ConfigError, match=error):
+        instantiate_guardrails(bundle)
 
     download.assert_not_called()
     subprocess_run.assert_not_called()
@@ -40,7 +58,8 @@ def test_local_spacy_model_is_supported(monkeypatch: pytest.MonkeyPatch, tmp_pat
     monkeypatch.setattr(spacy.util, "is_package", lambda _: False)
     _get_analyzer_engine.cache_clear()
 
-    _get_analyzer_engine()
+    bundle = ConfigBundle(guardrails=[GuardrailConfig(name="Contains PII", config={"entities": ["EMAIL_ADDRESS"]})])
+    instantiate_guardrails(bundle)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Presidio calls spaCy's downloader when the PII model is missing, which can invoke pip from the serving process. Fail before that path, provision the model during installation or deployment, and remove pip from runtime dependencies. Remove the unused Secret Keys analyzer that could trigger the same behavior.