### PR TITLE
Run sync checks in a worker thread

### DIFF
--- a/src/guardrails/runtime.py
+++ b/src/guardrails/runtime.py
@@ -67,10 +67,14 @@ class ConfiguredGuardrail(Generic[TContext, TIn, TCfg]):
         Returns:
             GuardrailResult: The result of the check function.
         """
-        result = fn(*a, **kw)
+        if inspect.iscoroutinefunction(fn):
+            async_fn = cast("Callable[P, Coroutine[Any, Any, GuardrailResult]]", fn)
+            return await async_fn(*a, **kw)
+
+        result = await asyncio.to_thread(fn, *a, **kw)
         if inspect.isawaitable(result):
             return await result
-        return cast("GuardrailResult", await asyncio.to_thread(lambda: result))
+        return result
 
     async def run(self, ctx: TContext, data: TIn) -> GuardrailResult:
         """Run the guardrail's check function with the provided context and data.

--- a/tests/unit/test_runtime.py
+++ b/tests/unit/test_runtime.py
@@ -1,6 +1,7 @@
 """Tests for the runtime module."""
 
 import sys
+import threading
 import types
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -14,6 +15,7 @@ from guardrails.exceptions import ConfigError, ContextValidationError, Guardrail
 from guardrails.registry import GuardrailRegistry
 from guardrails.runtime import (
     ConfigBundle,
+    ConfiguredGuardrail,
     GuardrailConfig,
     PipelineBundles,
     check_plain_text,
@@ -22,6 +24,7 @@ from guardrails.runtime import (
     load_pipeline_bundles,
     run_guardrails,
 )
+from guardrails.spec import GuardrailSpec
 from guardrails.types import GuardrailResult
 
 THRESHOLD = 2
@@ -104,6 +107,38 @@ def build_registry() -> GuardrailRegistry:
         media_type="text/plain",
     )
     return registry
+
+
+@pytest.mark.asyncio
+async def test_configured_guardrail_runs_sync_check_in_worker_thread() -> None:
+    """Synchronous checks should not execute on the event-loop thread."""
+    event_loop_thread_id = threading.get_ident()
+    check_thread_id: int | None = None
+
+    def sync_check(ctx: Any, data: str, config: LenCfg) -> GuardrailResult:
+        _ = ctx, data, config
+        nonlocal check_thread_id
+        check_thread_id = threading.get_ident()
+        return GuardrailResult(tripwire_triggered=False)
+
+    guardrail = ConfiguredGuardrail(
+        definition=GuardrailSpec(
+            name="sync",
+            description="synchronous check",
+            media_type="text/plain",
+            config_schema=LenCfg,
+            check_fn=sync_check,
+            ctx_requirements=BaseModel,
+            metadata=None,
+        ),
+        config=LenCfg(threshold=THRESHOLD),
+    )
+
+    result = await guardrail.run(None, "value")
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert check_thread_id is not None  # noqa: S101
+    assert check_thread_id != event_loop_thread_id  # noqa: S101
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- run synchronous guardrail checks in a worker thread
- continue awaiting asynchronous checks directly
- preserve support for synchronous callables that return awaitables
- add regression coverage that verifies the check runs outside the event-loop thread

## Why

ConfiguredGuardrail._ensure_async called synchronous checks before passing their completed result to asyncio.to_thread. The check itself therefore still ran on the event-loop thread and could block concurrent work.

## Testing

- uv run ruff check
- uv run pytest -q (437 passed)