### PR TITLE
Validate safety identifier endpoint hosts

### DIFF
--- a/src/guardrails/utils/safety_identifier.py
+++ b/src/guardrails/utils/safety_identifier.py
@@ -10,6 +10,7 @@ be sent to Azure OpenAI or other OpenAI-compatible providers.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
     from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
@@ -59,9 +60,11 @@ def supports_safety_identifier(
     # Check if using a custom base_url (local or alternative provider)
     base_url = getattr(client, "base_url", None)
     if base_url is not None:
-        base_url_str = str(base_url)
         # Only official OpenAI API endpoints support safety_identifier
-        return "api.openai.com" in base_url_str
+        hostname = urlparse(str(base_url)).hostname
+        if hostname is None:
+            return False
+        return hostname == "api.openai.com" or hostname.endswith(".api.openai.com")
 
     # Default OpenAI client (no custom base_url) supports it
     return True

--- a/tests/unit/test_safety_identifier.py
+++ b/tests/unit/test_safety_identifier.py
@@ -16,15 +16,42 @@ def test_supports_safety_identifier_for_openai_client() -> None:
     assert supports_safety_identifier(mock_client) is True  # noqa: S101
 
 
-def test_supports_safety_identifier_for_openai_with_official_url() -> None:
-    """OpenAI client with explicit api.openai.com base_url should support safety_identifier."""
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.openai.com/v1",
+        "https://eu.api.openai.com/v1",
+        "https://us.api.openai.com/v1",
+    ],
+)
+def test_supports_safety_identifier_for_openai_with_official_url(base_url: str) -> None:
+    """OpenAI clients with official base URLs should support safety_identifier."""
     from guardrails.utils.safety_identifier import supports_safety_identifier
 
     mock_client = Mock()
-    mock_client.base_url = "https://api.openai.com/v1"
+    mock_client.base_url = base_url
     mock_client.__class__.__name__ = "AsyncOpenAI"
 
     assert supports_safety_identifier(mock_client) is True  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.openai.com.evil.example/v1",
+        "https://api.openai.com@evil.example/v1",
+        "https://evilapi.openai.com/v1",
+    ],
+)
+def test_does_not_support_safety_identifier_for_misleading_hostname(base_url: str) -> None:
+    """Lookalike URLs should not be treated as the official endpoint."""
+    from guardrails.utils.safety_identifier import supports_safety_identifier
+
+    mock_client = Mock()
+    mock_client.base_url = base_url
+    mock_client.__class__.__name__ = "AsyncOpenAI"
+
+    assert supports_safety_identifier(mock_client) is False  # noqa: S101
 
 
 def test_does_not_support_safety_identifier_for_azure() -> None:


### PR DESCRIPTION
## Summary

- parse custom base URLs before deciding whether the safety identifier is supported
- accept the primary API hostname and anchored regional subdomains
- reject suffix-domain, userinfo, and missing-boundary lookalikes
- add regression coverage for primary, European, and US regional endpoints

## Why

The previous substring check treated any URL containing api.openai.com as an official endpoint. An exact-host replacement fixed those lookalikes but excluded official regional endpoints such as eu.api.openai.com.

Matching the primary hostname or an anchored subdomain preserves regional endpoint support without accepting attacker-controlled suffix domains.

## Testing

- uv run ruff check
- uv run mypy src/guardrails/utils/safety_identifier.py
- uv run pyright src/guardrails/utils/safety_identifier.py
- uv run pytest -q (441 passed)