### PR TITLE
Strip only the leading www. label when matching hosts

### DIFF
--- a/src/guardrails/checks/text/urls.py
+++ b/src/guardrails/checks/text/urls.py
@@ -42,6 +42,24 @@ DEFAULT_PORTS = {
 
 SCHEME_PREFIX_RE = re.compile(r"^[a-z][a-z0-9+.-]*://")
 
+WWW_PREFIX = "www."
+
+
+def _strip_www_prefix(host: str) -> str:
+    """Remove a single leading ``www.`` label from a host.
+
+    Only the leading label is normalized away. Stripping every occurrence
+    would let unrelated hosts collapse onto one another, so that
+    ``exwww.ample.com`` would compare equal to ``example.com``.
+
+    Args:
+        host: Lowercased host, optionally followed by a path.
+
+    Returns:
+        str: The host without its leading ``www.`` label.
+    """
+    return host.removeprefix(WWW_PREFIX)
+
 
 @dataclass(frozen=True, slots=True)
 class UrlDetectionResult:
@@ -186,7 +204,7 @@ def _detect_urls(text: str) -> list[str]:
                 if parsed.hostname:
                     scheme_url_domains.add(parsed.hostname.lower())
                     # Also add www-stripped version
-                    bare_domain = parsed.hostname.lower().replace("www.", "")
+                    bare_domain = _strip_www_prefix(parsed.hostname.lower())
                     scheme_url_domains.add(bare_domain)
             except (ValueError, UnicodeError):
                 # Skip URLs with parsing errors (malformed URLs, encoding issues)
@@ -198,7 +216,7 @@ def _detect_urls(text: str) -> list[str]:
     for url in detected_urls:
         if "://" not in url:
             # Check if this domain is already covered by a full URL
-            url_lower = url.lower().replace("www.", "")
+            url_lower = _strip_www_prefix(url.lower())
             if url_lower not in scheme_url_domains:
                 final_urls.append(url)
 
@@ -318,7 +336,7 @@ def _is_url_allowed(
         return False
 
     url_host = url_host.lower()
-    url_domain = url_host.replace("www.", "")
+    url_domain = _strip_www_prefix(url_host)
     scheme_lower = parsed_url.scheme.lower() if parsed_url.scheme else ""
     # Safely get port (rejects malformed ports)
     url_port = _safe_get_port(parsed_url, scheme_lower)
@@ -388,7 +406,7 @@ def _is_url_allowed(
         if not allowed_host:
             continue
 
-        allowed_domain = allowed_host.replace("www.", "")
+        allowed_domain = _strip_www_prefix(allowed_host)
 
         # Port matching: enforce if allow list has explicit port
         if allowed_port_explicit is not None and allowed_port != url_port:

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -462,3 +462,58 @@ async def test_urls_guardrail_blocks_subdomains_and_paths_correctly() -> None:
     assert len(result.info["blocked"]) == 2  # noqa: S101
     assert "help-suntropy.es" in result.info["blocked"]  # noqa: S101
     assert "help.suntropy.es" in result.info["blocked"]  # noqa: S101
+
+
+def test_is_url_allowed_rejects_host_with_embedded_www_label() -> None:
+    """A host that only matches after stripping an interior 'www.' must not be allowed."""
+    config = URLConfig(url_allow_list=["example.com"], allow_subdomains=False)
+    parsed, reason, had_scheme = _validate_url_security("https://exwww.ample.com/steal", config)
+
+    assert parsed is not None, reason  # noqa: S101
+    assert _is_url_allowed(parsed, config.url_allow_list, config.allow_subdomains, had_scheme) is False  # noqa: S101
+
+
+def test_is_url_allowed_rejects_allow_list_entry_with_embedded_www_label() -> None:
+    """An allow list entry with an interior 'www.' must not widen to an unrelated host."""
+    config = URLConfig(url_allow_list=["exwww.ample.com"], allow_subdomains=False)
+    parsed, reason, had_scheme = _validate_url_security("https://example.com/", config)
+
+    assert parsed is not None, reason  # noqa: S101
+    assert _is_url_allowed(parsed, config.url_allow_list, config.allow_subdomains, had_scheme) is False  # noqa: S101
+
+
+def test_is_url_allowed_still_normalizes_leading_www_label() -> None:
+    """Normalizing the leading 'www.' label must keep working in both directions."""
+    bare_allow = URLConfig(url_allow_list=["example.com"], allow_subdomains=False)
+    www_allow = URLConfig(url_allow_list=["www.example.com"], allow_subdomains=False)
+    www_url, www_reason, www_scheme = _validate_url_security("https://www.example.com", bare_allow)
+    bare_url, bare_reason, bare_scheme = _validate_url_security("https://example.com", www_allow)
+
+    assert www_url is not None, www_reason  # noqa: S101
+    assert bare_url is not None, bare_reason  # noqa: S101
+    assert _is_url_allowed(www_url, bare_allow.url_allow_list, False, www_scheme) is True  # noqa: S101
+    assert _is_url_allowed(bare_url, www_allow.url_allow_list, False, bare_scheme) is True  # noqa: S101
+
+
+def test_detect_urls_keeps_domain_not_covered_by_embedded_www_host() -> None:
+    """Dedup must not drop a bare domain that merely resembles a www-stripped host."""
+    detected = _detect_urls("see https://exwww.ample.com and also example.com here")
+
+    assert "https://exwww.ample.com" in detected  # noqa: S101
+    assert "example.com" in detected  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_embedded_www_lookalike() -> None:
+    """End to end, a lookalike host must trip the guardrail instead of being allowed."""
+    config = URLConfig(
+        url_allow_list=["example.com"],
+        allowed_schemes={"https"},
+        allow_subdomains=False,
+    )
+
+    result = await urls(ctx=None, data="Please visit https://exwww.ample.com/steal", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert "https://exwww.ample.com/steal" in result.info["blocked"]  # noqa: S101


### PR DESCRIPTION
The URL Filter normalizes hosts with `str.replace("www.", "")`, which removes that substring wherever it occurs rather than only the leading label. Hosts that contain a `www.` label anywhere in the middle therefore normalize to a different host than they actually are, so allow-list comparisons can match the wrong domain in both directions.

The same normalization runs in the detection dedup pass, where two distinct hosts can collapse onto one key and one of the URLs is dropped from the result before it is ever evaluated.

This replaces the substring strip with a small `_strip_www_prefix` helper built on `removeprefix`, applied at all four comparison sites, so only a genuine leading `www.` label is normalized away. Five regression tests cover the mismatch in both directions, the dedup collision, the end to end guardrail result, and a guard that ordinary leading `www.` normalization still matches as before.

Verified by restoring `src/guardrails/checks/text/urls.py` to upstream and rerunning: 4 of the 5 new tests fail, and the fifth is the no-over-correction guard that is expected to pass either way. With the fix, `tests/unit/checks/test_urls.py` is 32 passed. ruff, ruff format, and mypy are clean on the changed file.
