### PR TITLE
fix: block ambiguous control-bearing URLs

### DIFF
--- a/src/guardrails/checks/text/urls.py
+++ b/src/guardrails/checks/text/urls.py
@@ -22,7 +22,9 @@ Example Usage:
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
+from heapq import merge
 from ipaddress import AddressValueError, ip_address, ip_network
 from typing import Any
 from urllib.parse import ParseResult, urlparse
@@ -41,9 +43,198 @@ DEFAULT_PORTS = {
 }
 
 SCHEME_PREFIX_RE = re.compile(r"^[a-z][a-z0-9+.-]*://")
-DOMAIN_HOST_CANDIDATE_RE = re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9.-]*", re.IGNORECASE)
+_DOMAIN_HOST_CANDIDATE_PATTERN = r"[a-zA-Z0-9][a-zA-Z0-9.-]*"
+DOMAIN_HOST_CANDIDATE_RE = re.compile(rf"\b{_DOMAIN_HOST_CANDIDATE_PATTERN}", re.IGNORECASE)
+_AMBIGUOUS_DOMAIN_PATTERN = rf"(?<![A-Za-z0-9])(?i:{_DOMAIN_HOST_CANDIDATE_PATTERN})"
+AMBIGUOUS_DOMAIN_HOST_CANDIDATE_RE = re.compile(_AMBIGUOUS_DOMAIN_PATTERN)
+_IP_URL_PATTERN = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]+)?(?:/[^\s]*)?"
+IP_URL_RE = re.compile(rf"\b{_IP_URL_PATTERN}")
+AMBIGUOUS_IP_URL_RE = re.compile(rf"(?<![A-Za-z0-9]){_IP_URL_PATTERN}")
 ASCII_LETTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 CASE_INSENSITIVE_ASCII_LETTERS = ASCII_LETTERS | frozenset("İıſK")
+ASCII_URL_CONTROL_CHARACTERS = "\t\n\r"
+AMBIGUOUS_URL_REASON = "Ambiguous URL containing ASCII control characters"
+
+_HIERARCHICAL_CONTROL_SENSITIVE_SCHEMES = frozenset(("http", "https", "ftp"))
+_HOSTLESS_CONTROL_SENSITIVE_SCHEMES = frozenset(("data", "javascript", "vbscript", "mailto"))
+_ASCII_URL_CONTROL_SET = frozenset(ASCII_URL_CONTROL_CHARACTERS)
+_ASCII_URL_CONTROL_RE = re.compile(r"[\t\n\r]")
+_ASCII_URL_CONTROL_TRANSLATION = str.maketrans("", "", ASCII_URL_CONTROL_CHARACTERS)
+_VALID_SCHEME_RE = re.compile(r"[a-z][a-z0-9+.-]*", re.ASCII | re.IGNORECASE)
+_ASCII_SCHEME_CHARACTER_SET = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+.-")
+_TRAILING_SENTENCE_PUNCTUATION = frozenset(".,;:!?")
+_POST_CONTROL_HARD_URL_BOUNDARIES = frozenset(('"', "`", "|", "^", "\\", "[", "{", "<"))
+_POST_CONTROL_HARD_URL_BOUNDARY_RE = re.compile(r'["`|^\\\[{<]')
+_PAIRED_DELIMITER_OPEN_CODES = {"(": 1, "[": 2, "{": 3, "<": 4}
+_PAIRED_DELIMITER_CLOSE_TO_OPEN_CODE = {")": 1, "]": 2, "}": 3, ">": 4}
+_PAIRED_DELIMITER_RE = re.compile(r"[()\[\]{}<>]")
+_DENSE_DELIMITER_SAMPLE_SIZE = 64
+_DENSE_DELIMITER_SAMPLE_WINDOW = 4_096
+_POST_CONTROL_UNMATCHED_URL_BOUNDARIES = frozenset(")]}>")
+_TRAILING_URL_BOUNDARIES = _TRAILING_SENTENCE_PUNCTUATION | _POST_CONTROL_HARD_URL_BOUNDARIES
+
+
+@dataclass(frozen=True, slots=True)
+class _AmbiguousSchemeMatcher:
+    """Reversed trie for linear control-bearing scheme detection.
+
+    Args:
+        transitions: Character transitions indexed by trie node.
+        hierarchical_nodes: Terminal nodes that accept a ``://`` suffix.
+        hostless_nodes: Terminal nodes that accept a single colon suffix.
+        hostless_first_nodes: Built-in hostless schemes whose colon form has
+            precedence over a configured hierarchical form.
+    """
+
+    transitions: tuple[dict[str, int], ...]
+    hierarchical_nodes: frozenset[int]
+    hostless_nodes: frozenset[int]
+    hostless_first_nodes: frozenset[int]
+
+
+@dataclass(frozen=True, slots=True)
+class _AmbiguousSchemeMatch:
+    """One raw scheme-prefix match in source text.
+
+    Args:
+        start: Inclusive raw offset of the scheme name.
+        end: Exclusive raw offset of the matched scheme prefix.
+        opens_authority: Whether the prefix ends in ``://``.
+    """
+
+    start: int
+    end: int
+    opens_authority: bool
+
+
+def _build_ambiguous_scheme_matcher(
+    allowed_schemes: set[str] | frozenset[str],
+) -> _AmbiguousSchemeMatcher:
+    """Build a reversed trie for built-in and configured schemes.
+
+    Args:
+        allowed_schemes: Normalized schemes allowed by the URL filter.
+
+    Returns:
+        An immutable matcher description for raw scheme scanning.
+    """
+    hierarchical_schemes: set[str] = set(_HIERARCHICAL_CONTROL_SENSITIVE_SCHEMES)
+    hostless_schemes: set[str] = set(_HOSTLESS_CONTROL_SENSITIVE_SCHEMES)
+    configured_schemes = {scheme.lower() for scheme in allowed_schemes if _VALID_SCHEME_RE.fullmatch(scheme) is not None}
+    hierarchical_schemes.update(configured_schemes)
+    hostless_schemes.update(configured_schemes)
+
+    transitions: list[dict[str, int]] = [{}]
+    hierarchical_nodes: set[int] = set()
+    hostless_nodes: set[int] = set()
+    hostless_first_nodes: set[int] = set()
+    all_schemes = hierarchical_schemes | hostless_schemes
+    for scheme in all_schemes:
+        node = 0
+        for character in reversed(scheme):
+            next_node = transitions[node].get(character)
+            if next_node is None:
+                next_node = len(transitions)
+                transitions[node][character] = next_node
+                transitions.append({})
+            node = next_node
+        if scheme in hierarchical_schemes:
+            hierarchical_nodes.add(node)
+        if scheme in hostless_schemes:
+            hostless_nodes.add(node)
+        if scheme in _HOSTLESS_CONTROL_SENSITIVE_SCHEMES:
+            hostless_first_nodes.add(node)
+
+    return _AmbiguousSchemeMatcher(
+        transitions=tuple(transitions),
+        hierarchical_nodes=frozenset(hierarchical_nodes),
+        hostless_nodes=frozenset(hostless_nodes),
+        hostless_first_nodes=frozenset(hostless_first_nodes),
+    )
+
+
+def _find_hierarchical_scheme_end(text: str, colon_position: int) -> int | None:
+    """Find a control-interleaved ``//`` suffix after a scheme colon.
+
+    Args:
+        text: Source text containing the scheme colon.
+        colon_position: Offset of the scheme colon.
+
+    Returns:
+        The exclusive offset after the second slash, or None when absent.
+    """
+    position = colon_position + 1
+    for _ in range(2):
+        while position < len(text) and text[position] in _ASCII_URL_CONTROL_SET:
+            position += 1
+        if position == len(text) or text[position] != "/":
+            return None
+        position += 1
+    return position
+
+
+def _find_ambiguous_scheme_matches(
+    text: str,
+    matcher: _AmbiguousSchemeMatcher,
+) -> list[_AmbiguousSchemeMatch]:
+    """Find scheme prefixes without repeated regex rescans.
+
+    Each colon terminates the backward scan for the preceding colon, so the
+    total amount of backward work is linear in the input length.
+
+    Args:
+        text: Source text to scan for scheme prefixes.
+        matcher: Reversed scheme trie and terminal metadata.
+
+    Returns:
+        Scheme-prefix matches ordered by source position.
+    """
+    matches: list[_AmbiguousSchemeMatch] = []
+    for colon_position, character in enumerate(text):
+        if character != ":":
+            continue
+
+        hierarchical_end = _find_hierarchical_scheme_end(text, colon_position)
+        node = 0
+        position = colon_position - 1
+        selected_match: _AmbiguousSchemeMatch | None = None
+        while position >= 0:
+            scheme_character = text[position]
+            if scheme_character in _ASCII_URL_CONTROL_SET:
+                position -= 1
+                continue
+            if scheme_character not in _ASCII_SCHEME_CHARACTER_SET:
+                break
+
+            next_node = matcher.transitions[node].get(scheme_character.lower())
+            if next_node is None:
+                break
+            node = next_node
+
+            if node in matcher.hostless_first_nodes:
+                match_end = colon_position + 1
+                opens_authority = False
+            elif hierarchical_end is not None and node in matcher.hierarchical_nodes:
+                match_end = hierarchical_end
+                opens_authority = True
+            elif node in matcher.hostless_nodes:
+                match_end = colon_position + 1
+                opens_authority = False
+            else:
+                position -= 1
+                continue
+
+            selected_match = _AmbiguousSchemeMatch(
+                start=position,
+                end=match_end,
+                opens_authority=opens_authority,
+            )
+            position -= 1
+
+        if selected_match is not None:
+            matches.append(selected_match)
+
+    return matches
 
 
 @dataclass(frozen=True, slots=True)
@@ -136,19 +327,23 @@ def _find_domain_end(host_candidate: str) -> int | None:
     return domain_end
 
 
-def _detect_domain_like_urls(text: str) -> list[str]:
-    """Detect scheme-less domain-like URLs in linear time.
+def _detect_domain_like_url_spans(
+    text: str,
+    candidate_re: re.Pattern[str] = DOMAIN_HOST_CANDIDATE_RE,
+) -> list[tuple[int, int]]:
+    """Detect scheme-less domain-like URL spans in linear time.
 
     Args:
         text: Text to scan for domain-like URLs.
+        candidate_re: Pattern locating maximal hostname-shaped text.
 
     Returns:
-        Domain-like URL matches using the existing detection semantics.
+        Inclusive start and exclusive end offsets for domain-like URLs.
     """
-    detected_domains: list[str] = []
+    detected_spans: list[tuple[int, int]] = []
     search_position = 0
 
-    while match := DOMAIN_HOST_CANDIDATE_RE.search(text, search_position):
+    while match := candidate_re.search(text, search_position):
         host_candidate = match.group(0)
         domain_end = _find_domain_end(host_candidate)
         if domain_end is None:
@@ -161,13 +356,683 @@ def _detect_domain_like_urls(text: str) -> list[str]:
             while match_end < len(text) and not text[match_end].isspace():
                 match_end += 1
 
-        detected_domains.append(text[match.start() : match_end])
+        detected_spans.append((match.start(), match_end))
         search_position = match_end
 
-    return detected_domains
+    return detected_spans
 
 
-def _detect_urls(text: str) -> list[str]:
+def _detect_domain_like_urls(text: str) -> list[str]:
+    """Detect scheme-less domain-like URLs in linear time.
+
+    Args:
+        text: Text to scan for domain-like URLs.
+
+    Returns:
+        Domain-like URL matches using the existing detection semantics.
+    """
+    return [text[start:end] for start, end in _detect_domain_like_url_spans(text)]
+
+
+def _use_dense_delimiter_scan(text: str) -> bool:
+    """Choose direct scanning when delimiters are densely clustered.
+
+    Args:
+        text: Candidate text whose delimiter density should be sampled.
+
+    Returns:
+        True when the initial delimiter sample fits within a small window.
+    """
+    first_match = _PAIRED_DELIMITER_RE.search(text)
+    if first_match is None:
+        return False
+
+    search_position = first_match.end()
+    for _ in range(_DENSE_DELIMITER_SAMPLE_SIZE):
+        match = _PAIRED_DELIMITER_RE.search(text, search_position)
+        if match is None:
+            return False
+        if match.start() - first_match.start() > _DENSE_DELIMITER_SAMPLE_WINDOW:
+            return False
+        search_position = match.end()
+
+    return True
+
+
+def _paired_delimiter_positions(text: str) -> Iterator[tuple[int, str]]:
+    """Iterate delimiter positions with a density-appropriate scan.
+
+    Args:
+        text: Candidate text whose delimiters should be located.
+
+    Returns:
+        An iterator over source offsets and delimiter characters.
+    """
+    if _use_dense_delimiter_scan(text):
+        return enumerate(text)
+    return ((match.start(), match.group(0)) for match in _PAIRED_DELIMITER_RE.finditer(text))
+
+
+def _mark_unmatched_closing_delimiters(text: str) -> bytearray | None:
+    """Mark closing delimiters without properly nested openers.
+
+    Args:
+        text: Candidate text whose paired delimiters should be inspected.
+
+    Returns:
+        A one-byte-per-character mask marking unmatched closing delimiters,
+        or None when every closing delimiter has a matching opener.
+    """
+    opening_delimiters = bytearray()
+    unmatched_positions: bytearray | None = None
+
+    for position, character in _paired_delimiter_positions(text):
+        opening_code = _PAIRED_DELIMITER_OPEN_CODES.get(character)
+        if opening_code is not None:
+            opening_delimiters.append(opening_code)
+            continue
+
+        expected_opening_code = _PAIRED_DELIMITER_CLOSE_TO_OPEN_CODE.get(character)
+        if expected_opening_code is None:
+            continue
+        if opening_delimiters and opening_delimiters[-1] == expected_opening_code:
+            opening_delimiters.pop()
+        else:
+            if unmatched_positions is None:
+                unmatched_positions = bytearray(len(text))
+            unmatched_positions[position] = 1
+
+    return unmatched_positions
+
+
+def _truncate_at_post_control_hard_boundary(
+    candidate: str,
+    minimum_length: int,
+    control_is_in_protected_prefix: bool,
+) -> str:
+    """Truncate an unprotected candidate at its first hard boundary.
+
+    Args:
+        candidate: Raw URL-like candidate to inspect.
+        minimum_length: Prefix length that must remain intact.
+        control_is_in_protected_prefix: Whether URL syntax after a controlled
+            scheme prefix must remain part of the candidate.
+
+    Returns:
+        The candidate prefix ending before the first applicable hard boundary.
+    """
+    if control_is_in_protected_prefix:
+        return candidate
+    hard_boundary_match = _POST_CONTROL_HARD_URL_BOUNDARY_RE.search(
+        candidate,
+        minimum_length,
+    )
+    if hard_boundary_match is None:
+        return candidate
+    return candidate[: hard_boundary_match.start()]
+
+
+def _truncate_at_unmatched_closing_boundary(
+    candidate: str,
+    minimum_length: int,
+    control_is_in_protected_prefix: bool,
+) -> str:
+    """Truncate an unprotected candidate at an unmatched closing delimiter.
+
+    Args:
+        candidate: Raw URL-like candidate to inspect.
+        minimum_length: Prefix length that must remain intact.
+        control_is_in_protected_prefix: Whether URL syntax after a controlled
+            scheme prefix must remain part of the candidate.
+
+    Returns:
+        The candidate prefix ending before the first applicable unmatched
+        closing delimiter.
+    """
+    if control_is_in_protected_prefix:
+        return candidate
+
+    opening_delimiters = bytearray()
+    for position, character in _paired_delimiter_positions(candidate):
+        opening_code = _PAIRED_DELIMITER_OPEN_CODES.get(character)
+        if opening_code is not None:
+            opening_delimiters.append(opening_code)
+            continue
+
+        expected_opening_code = _PAIRED_DELIMITER_CLOSE_TO_OPEN_CODE.get(character)
+        if expected_opening_code is None:
+            continue
+        if opening_delimiters and opening_delimiters[-1] == expected_opening_code:
+            opening_delimiters.pop()
+        elif position >= minimum_length:
+            return candidate[:position]
+
+    return candidate
+
+
+def _clean_ambiguous_url_candidate(candidate: str, minimum_length: int) -> str:
+    """Remove Markdown boundaries and trailing sentence punctuation.
+
+    Args:
+        candidate: Raw URL-like candidate to clean.
+        minimum_length: Prefix length that must remain intact.
+
+    Returns:
+        The candidate without confirmed Markdown syntax, trailing sentence
+        punctuation, or unmatched trailing delimiters. The final ASCII URL
+        control is always preserved.
+    """
+    url_controls = ASCII_URL_CONTROL_CHARACTERS
+    first_control_position = min(
+        (candidate.find(control) for control in url_controls if control in candidate),
+        default=-1,
+    )
+    markdown_boundary = candidate.find(
+        "](",
+        max(minimum_length, first_control_position + 1),
+    )
+    if first_control_position != -1 and markdown_boundary != -1:
+        candidate = candidate[:markdown_boundary]
+
+    last_control_position = max(
+        (candidate.rfind(control) for control in ASCII_URL_CONTROL_CHARACTERS),
+        default=-1,
+    )
+    control_is_in_protected_prefix = minimum_length > 0 and last_control_position < minimum_length
+    minimum_length = max(minimum_length, last_control_position + 1)
+    unmatched_boundaries = _POST_CONTROL_UNMATCHED_URL_BOUNDARIES
+
+    candidate = _truncate_at_post_control_hard_boundary(
+        candidate,
+        minimum_length,
+        control_is_in_protected_prefix,
+    )
+    candidate = _truncate_at_unmatched_closing_boundary(
+        candidate,
+        minimum_length,
+        control_is_in_protected_prefix,
+    )
+
+    if not control_is_in_protected_prefix:
+        unmatched_mask: bytearray | None = None
+    else:
+        unmatched_mask = _mark_unmatched_closing_delimiters(candidate)
+
+    candidate_end = len(candidate)
+    while candidate_end > minimum_length:
+        trailing_position = candidate_end - 1
+        delimiter = candidate[trailing_position]
+        is_unmatched = unmatched_mask is not None and bool(unmatched_mask[trailing_position])
+        if is_unmatched and unmatched_mask is not None:
+            previous_matched_position = unmatched_mask.rfind(
+                b"\x00",
+                minimum_length,
+                candidate_end,
+            )
+            candidate_end = max(minimum_length, previous_matched_position + 1)
+            continue
+        has_unmatched_delimiter = is_unmatched and delimiter in unmatched_boundaries
+        is_trailing_boundary = delimiter in _TRAILING_URL_BOUNDARIES
+        is_trailing_boundary = is_trailing_boundary or has_unmatched_delimiter
+        if not is_trailing_boundary:
+            break
+        candidate_end -= 1
+
+    return candidate[:candidate_end]
+
+
+def _is_non_control_whitespace(character: str) -> bool:
+    """Check whether a character terminates an ambiguous URL candidate.
+
+    Args:
+        character: Character to classify.
+
+    Returns:
+        True for whitespace other than ASCII TAB, LF, and CR.
+    """
+    return character.isspace() and character not in _ASCII_URL_CONTROL_SET
+
+
+def _find_userinfo_marker_before_path_boundary(
+    text: str,
+    search_start: int,
+) -> int | None:
+    """Find the next userinfo marker in the current authority.
+
+    Args:
+        text: Source text containing the authority.
+        search_start: Offset where the forward search begins.
+
+    Returns:
+        The next userinfo marker offset, or None if a path, query, fragment,
+        or the end of the text is reached first.
+    """
+    for position in range(search_start, len(text)):
+        character = text[position]
+        if character in "/?#":
+            return None
+        if character == "@":
+            return position
+
+    return None
+
+
+def _refresh_userinfo_marker(
+    text: str,
+    whitespace_position: int,
+    cached_marker: int | None,
+) -> int | None:
+    """Reuse or refresh the next userinfo marker for an authority.
+
+    Args:
+        text: Source text containing the authority.
+        whitespace_position: Current non-control whitespace offset.
+        cached_marker: Previously located userinfo marker, if any.
+
+    Returns:
+        A cached or newly located userinfo marker, or None before a path
+        boundary or the end of the text.
+    """
+    if cached_marker is not None and whitespace_position < cached_marker:
+        return cached_marker
+    return _find_userinfo_marker_before_path_boundary(
+        text,
+        whitespace_position + 1,
+    )
+
+
+def _scan_url_like_segment(
+    text: str,
+    segment_start: int,
+    scheme_matches_by_start: dict[int, _AmbiguousSchemeMatch],
+) -> tuple[int, bool]:
+    """Find a URL-like segment end without splitting userinfo syntax.
+
+    Args:
+        text: Source text to scan.
+        segment_start: Inclusive offset where the segment begins.
+        scheme_matches_by_start: Scheme-prefix matches keyed by source start.
+
+    Returns:
+        The exclusive segment end and whether it contains an ASCII URL
+        control character.
+    """
+    segment_end = segment_start
+    has_control = False
+    authority_is_open = False
+    authority_opens_at: int | None = None
+    next_userinfo_marker: int | None = None
+
+    while segment_end < len(text):
+        if authority_opens_at is None:
+            scheme_match = scheme_matches_by_start.get(segment_end)
+            if scheme_match is not None and scheme_match.opens_authority:
+                authority_opens_at = scheme_match.end
+
+        character = text[segment_end]
+        if not _is_non_control_whitespace(character):
+            if character in _ASCII_URL_CONTROL_SET:
+                has_control = True
+            if character in "/?#":
+                authority_is_open = False
+                next_userinfo_marker = None
+            segment_end += 1
+            if segment_end == authority_opens_at:
+                authority_is_open = True
+                authority_opens_at = None
+            continue
+
+        if not authority_is_open:
+            break
+
+        next_userinfo_marker = _refresh_userinfo_marker(
+            text,
+            segment_end,
+            next_userinfo_marker,
+        )
+        if next_userinfo_marker is None:
+            break
+        segment_end += 1
+
+    return segment_end, has_control
+
+
+def _scan_ambiguous_url_candidate(
+    text: str,
+    scheme_start: int,
+    scheme_end: int,
+    segment_end: int,
+    scheme_matches_by_start: dict[int, _AmbiguousSchemeMatch],
+) -> tuple[str | None, int]:
+    """Scan one possible control-bearing URL candidate in linear time.
+
+    Args:
+        text: Source text containing the matched scheme.
+        scheme_start: Inclusive offset of the matched scheme.
+        scheme_end: Exclusive offset of the matched scheme.
+        segment_end: Exclusive offset of the non-whitespace segment.
+        scheme_matches_by_start: Scheme-prefix matches keyed by source start.
+
+    Returns:
+        The cleaned raw candidate when ambiguous, plus the exclusive offset
+        scanned. The candidate is None when no ASCII URL control was included.
+    """
+    matched_scheme = text[scheme_start:scheme_end]
+    has_control = not _ASCII_URL_CONTROL_SET.isdisjoint(matched_scheme)
+    candidate_end = scheme_end
+
+    while candidate_end < segment_end:
+        character = text[candidate_end]
+        if character == "]" and candidate_end + 1 < segment_end and text[candidate_end + 1] == "(":
+            nested_scheme = scheme_matches_by_start.get(candidate_end + 2)
+            if has_control or nested_scheme is not None:
+                break
+        if character in _ASCII_URL_CONTROL_SET:
+            has_control = True
+        candidate_end += 1
+
+    if not has_control:
+        return None, candidate_end
+
+    raw_candidate = text[scheme_start:candidate_end]
+    protected_prefix_end = scheme_end
+    while protected_prefix_end < candidate_end:
+        if text[protected_prefix_end] not in _ASCII_URL_CONTROL_SET:
+            break
+        protected_prefix_end += 1
+    candidate = _clean_ambiguous_url_candidate(
+        raw_candidate,
+        minimum_length=protected_prefix_end - scheme_start,
+    )
+    return candidate, candidate_end
+
+
+def _normalize_url_control_segment(
+    text: str,
+    segment_start: int,
+    segment_end: int,
+) -> tuple[str, list[int]]:
+    """Remove URL controls while preserving source position mappings.
+
+    Args:
+        text: Source text containing the segment.
+        segment_start: Inclusive segment offset.
+        segment_end: Exclusive segment offset.
+
+    Returns:
+        Control-stripped text and the raw positions of removed controls.
+    """
+    segment = text[segment_start:segment_end]
+    normalized_text = segment.translate(_ASCII_URL_CONTROL_TRANSLATION)
+    control_matches = _ASCII_URL_CONTROL_RE.finditer(segment)
+    control_positions = [segment_start + match.start() for match in control_matches]
+    return normalized_text, control_positions
+
+
+def _find_raw_scheme_less_candidate_starts(
+    text: str,
+    normalized_text: str,
+    segment_start: int,
+    segment_end: int,
+    control_positions: list[int],
+) -> list[int]:
+    """Find raw starts from normalized and source URL boundaries.
+
+    Args:
+        text: Source text containing the raw segment.
+        normalized_text: Segment text with ASCII URL controls removed.
+        segment_start: Raw offset where the normalized segment begins.
+        segment_end: Exclusive raw offset where the segment ends.
+        control_positions: Raw positions of removed controls.
+
+    Returns:
+        Sorted, unique raw starts for scheme-less URL candidates.
+    """
+    if not normalized_text:
+        return []
+
+    # These ASCII-boundary patterns cover the ordinary ``\b`` matches and
+    # may conservatively start earlier after a Unicode word character.
+    domain_spans = _detect_domain_like_url_spans(
+        normalized_text,
+        AMBIGUOUS_DOMAIN_HOST_CANDIDATE_RE,
+    )
+    ambiguous_ip_matches = AMBIGUOUS_IP_URL_RE.finditer(normalized_text)
+    ambiguous_ip_spans = ((match.start(), match.end()) for match in ambiguous_ip_matches)
+    raw_starts: list[int] = []
+    first_content_position = segment_start
+    for control_position in control_positions:
+        if control_position != first_content_position:
+            break
+        first_content_position += 1
+    first_inner_control = next(
+        (position for position in control_positions if position > first_content_position),
+        None,
+    )
+    previous_normalized_start: int | None = None
+    control_index = 0
+    control_count = len(control_positions)
+    for normalized_start, _ in merge(
+        domain_spans,
+        ambiguous_ip_spans,
+    ):
+        if normalized_start == previous_normalized_start:
+            continue
+        previous_normalized_start = normalized_start
+        raw_start = segment_start + normalized_start + control_index
+        while control_index < control_count and control_positions[control_index] <= raw_start:
+            raw_start += 1
+            control_index += 1
+        if not raw_starts or raw_starts[-1] != raw_start:
+            raw_starts.append(raw_start)
+
+    if not raw_starts:
+        # A control can create an ordinary raw boundary that disappears when
+        # normalization joins an ASCII prefix to an IP-shaped suffix.
+        raw_segment = text[segment_start:segment_end]
+        raw_domain_spans = _detect_domain_like_url_spans(raw_segment)
+        raw_ip_matches = IP_URL_RE.finditer(raw_segment)
+        raw_ip_spans = ((match.start(), match.end()) for match in raw_ip_matches)
+        for raw_start, _ in merge(raw_domain_spans, raw_ip_spans):
+            source_start = segment_start + raw_start
+            if not raw_starts or raw_starts[-1] != source_start:
+                raw_starts.append(source_start)
+
+    if raw_starts and first_inner_control is not None and first_inner_control < raw_starts[0]:
+        raw_starts[0] = first_content_position
+
+    return raw_starts
+
+
+def _join_scheme_less_userinfo_spans(
+    text: str,
+    raw_starts: list[int],
+    segment_end: int,
+) -> Iterator[tuple[int, int]]:
+    """Join scheme-less domains separated by userinfo markers.
+
+    Args:
+        text: Source text containing the URL-like segment.
+        raw_starts: Sorted raw starts of domain and IP matches.
+        segment_end: Exclusive end of the URL-like segment.
+
+    Returns:
+        An iterator of candidate spans with domains around ``@`` kept
+        together.
+    """
+    start_index = 0
+    while start_index < len(raw_starts):
+        raw_start = raw_starts[start_index]
+        next_start_index = start_index + 1
+        while (
+            next_start_index < len(raw_starts)
+            and text.find(
+                "@",
+                raw_starts[next_start_index - 1],
+                raw_starts[next_start_index],
+            )
+            != -1
+        ):
+            next_start_index += 1
+        if next_start_index < len(raw_starts):
+            raw_end = raw_starts[next_start_index]
+        else:
+            raw_end = segment_end
+        yield raw_start, raw_end
+        start_index = next_start_index
+
+
+def _find_control_bearing_scheme_less_candidates(
+    text: str,
+    segment_start: int,
+    segment_end: int,
+    occupied_spans: list[tuple[int, int]],
+) -> list[tuple[str, tuple[int, int]]]:
+    """Map control-stripped domain and IP matches back to raw spans.
+
+    The control-stripped text is used only to discover candidates. Returned
+    candidates always preserve the raw source text for fail-closed handling.
+
+    Args:
+        text: Source text containing the segment.
+        segment_start: Inclusive segment offset.
+        segment_end: Exclusive segment offset.
+        occupied_spans: Explicit-scheme spans already claimed in the segment.
+
+    Returns:
+        Raw control-bearing scheme-less candidates and their source spans.
+    """
+    if occupied_spans:
+        first_occupied_start, first_occupied_end = occupied_spans[0]
+        if first_occupied_start <= segment_start and segment_end <= first_occupied_end:
+            return []
+
+    normalized_text, control_positions = _normalize_url_control_segment(
+        text,
+        segment_start,
+        segment_end,
+    )
+    raw_starts = _find_raw_scheme_less_candidate_starts(
+        text,
+        normalized_text,
+        segment_start,
+        segment_end,
+        control_positions,
+    )
+    raw_spans = _join_scheme_less_userinfo_spans(text, raw_starts, segment_end)
+
+    candidates: list[tuple[str, tuple[int, int]]] = []
+    control_index = 0
+    occupied_index = 0
+    occupied_count = len(occupied_spans)
+    control_count = len(control_positions)
+    for raw_start, raw_end in raw_spans:
+        while occupied_index < occupied_count and occupied_spans[occupied_index][1] <= raw_start:
+            occupied_index += 1
+        if occupied_index < occupied_count:
+            occupied_start, occupied_end = occupied_spans[occupied_index]
+            if occupied_start <= raw_start < occupied_end:
+                continue
+            raw_end = min(raw_end, occupied_start)
+
+        while control_index < control_count and control_positions[control_index] < raw_start:
+            control_index += 1
+        if control_index == control_count or control_positions[control_index] >= raw_end:
+            continue
+
+        raw_candidate = text[raw_start:raw_end]
+        candidate = _clean_ambiguous_url_candidate(raw_candidate, minimum_length=0)
+        candidates.append((candidate, (raw_start, raw_start + len(candidate))))
+
+    return candidates
+
+
+def _find_ambiguous_url_candidates(
+    text: str,
+    allowed_schemes: set[str] | frozenset[str] = frozenset(),
+) -> list[tuple[str, tuple[int, int]]]:
+    """Find raw control-bearing URL candidates and their source spans.
+
+    Args:
+        text: Text to scan for ambiguous URL-like candidates.
+        allowed_schemes: Additional configured scheme names to recognize.
+
+    Returns:
+        Raw candidates paired with their source spans.
+    """
+    next_control_match = _ASCII_URL_CONTROL_RE.search(text)
+    if next_control_match is None:
+        return []
+
+    scheme_matcher = _build_ambiguous_scheme_matcher(allowed_schemes)
+    scheme_matches = _find_ambiguous_scheme_matches(text, scheme_matcher)
+    scheme_matches_by_start = {match.start: match for match in scheme_matches}
+    candidates: list[tuple[str, tuple[int, int]]] = []
+    segment_start = 0
+    scheme_match_index = 0
+
+    while segment_start < len(text) and next_control_match is not None:
+        while segment_start < len(text) and _is_non_control_whitespace(text[segment_start]):
+            segment_start += 1
+        if segment_start == len(text):
+            break
+
+        segment_end, has_segment_control = _scan_url_like_segment(
+            text,
+            segment_start,
+            scheme_matches_by_start,
+        )
+
+        if not has_segment_control:
+            segment_start = segment_end
+            continue
+
+        segment_candidates: list[tuple[str, tuple[int, int]]] = []
+        search_position = segment_start
+        while scheme_match_index < len(scheme_matches) and scheme_matches[scheme_match_index].start < segment_start:
+            scheme_match_index += 1
+        while scheme_match_index < len(scheme_matches) and scheme_matches[scheme_match_index].start < segment_end:
+            match = scheme_matches[scheme_match_index]
+            scheme_match_index += 1
+            if match.start < search_position:
+                continue
+            candidate, candidate_end = _scan_ambiguous_url_candidate(
+                text,
+                match.start,
+                match.end,
+                segment_end,
+                scheme_matches_by_start,
+            )
+            search_position = max(match.end, candidate_end)
+            if candidate is not None:
+                candidate_span = (match.start, match.start + len(candidate))
+                segment_candidates.append((candidate, candidate_span))
+
+        occupied_spans = [span for _, span in segment_candidates]
+        scheme_less_candidates = _find_control_bearing_scheme_less_candidates(
+            text,
+            segment_start,
+            segment_end,
+            occupied_spans,
+        )
+        candidates.extend(
+            merge(
+                segment_candidates,
+                scheme_less_candidates,
+                key=lambda item: item[1],
+            )
+        )
+
+        next_control_match = _ASCII_URL_CONTROL_RE.search(text, segment_end)
+        segment_start = segment_end
+
+    return candidates
+
+
+def _detect_urls(
+    text: str,
+    allowed_schemes: set[str] | frozenset[str] = frozenset(),
+) -> list[str]:
     """Detect URLs using regex patterns with deduplication.
 
     Detects URLs with explicit schemes (http, https, ftp, data, javascript,
@@ -177,6 +1042,7 @@ def _detect_urls(text: str) -> list[str]:
 
     Args:
         text: The text to scan for URLs.
+        allowed_schemes: Additional configured scheme names to recognize.
 
     Returns:
         List of unique URL strings found in the text, with trailing
@@ -185,7 +1051,15 @@ def _detect_urls(text: str) -> list[str]:
     # Pattern for cleaning trailing punctuation (] must be escaped)
     PUNCTUATION_CLEANUP = r"[.,;:!?)\]]+$"
 
-    detected_urls = []
+    ambiguous_candidates = _find_ambiguous_url_candidates(text, allowed_schemes)
+    detected_urls = [candidate for candidate, _ in ambiguous_candidates]
+    if ambiguous_candidates:
+        detection_characters = list(text)
+        for _, (start, end) in ambiguous_candidates:
+            detection_characters[start:end] = " " * (end - start)
+        text_without_ambiguous_candidates = "".join(detection_characters)
+    else:
+        text_without_ambiguous_candidates = text
 
     # Pattern 1: URLs with schemes (highest priority)
     scheme_patterns = [
@@ -198,7 +1072,7 @@ def _detect_urls(text: str) -> list[str]:
 
     scheme_urls = set()
     for pattern in scheme_patterns:
-        matches = re.findall(pattern, text, re.IGNORECASE)
+        matches = re.findall(pattern, text_without_ambiguous_candidates, re.IGNORECASE)
         for match in matches:
             # Clean trailing punctuation
             cleaned = re.sub(PUNCTUATION_CLEANUP, "", match)
@@ -210,7 +1084,7 @@ def _detect_urls(text: str) -> list[str]:
                     scheme_urls.add(domain_part.lower())
 
     # Pattern 2: Domain-like patterns (scheme-less) - but skip if already found with scheme
-    domain_matches = _detect_domain_like_urls(text)
+    domain_matches = _detect_domain_like_urls(text_without_ambiguous_candidates)
 
     for match in domain_matches:
         # Clean trailing punctuation
@@ -223,8 +1097,7 @@ def _detect_urls(text: str) -> list[str]:
                 detected_urls.append(cleaned)
 
     # Pattern 3: IP addresses - similar deduplication
-    ip_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]+)?(?:/[^\s]*)?"
-    ip_matches = re.findall(ip_pattern, text, re.IGNORECASE)
+    ip_matches = IP_URL_RE.findall(text_without_ambiguous_candidates)
 
     for match in ip_matches:
         # Clean trailing punctuation
@@ -495,12 +1368,17 @@ async def urls(ctx: Any, data: str, config: URLConfig) -> GuardrailResult:
     _ = ctx
 
     # Detect URLs using regex patterns
-    detected_urls = _detect_urls(data)
+    detected_urls = _detect_urls(data, config.allowed_schemes)
 
     allowed, blocked = [], []
     blocked_reasons = []
 
     for url_string in detected_urls:
+        if any(character in url_string for character in ASCII_URL_CONTROL_CHARACTERS):
+            blocked.append(url_string)
+            blocked_reasons.append(f"{url_string}: {AMBIGUOUS_URL_REASON}")
+            continue
+
         # Validate URL with security checks
         parsed_url, error_reason, url_had_explicit_scheme = _validate_url_security(url_string, config)
 

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -2,19 +2,31 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 import string
+from datetime import timedelta
 from statistics import median
 from timeit import repeat
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given, settings, strategies as st
+from hypothesis.strategies import DrawFn
 
 from guardrails.checks.text.urls import (
+    AMBIGUOUS_DOMAIN_HOST_CANDIDATE_RE,
+    AMBIGUOUS_IP_URL_RE,
+    AMBIGUOUS_URL_REASON,
+    DOMAIN_HOST_CANDIDATE_RE,
+    IP_URL_RE,
     URLConfig,
+    _clean_ambiguous_url_candidate,
+    _detect_domain_like_url_spans,
     _detect_domain_like_urls,
     _detect_urls,
+    _find_ambiguous_url_candidates,
     _is_url_allowed,
+    _mark_unmatched_closing_delimiters,
     _validate_url_security,
     urls,
 )
@@ -65,6 +77,33 @@ def test_detect_domain_like_urls_matches_reference_pattern(text: str) -> None:
     assert _detect_domain_like_urls(text) == REFERENCE_DOMAIN_PATTERN.findall(text)  # noqa: S101
 
 
+@given(
+    text=st.text(
+        alphabet=string.ascii_letters + string.digits + string.punctuation + "é中 ",
+        max_size=100,
+    )
+)
+def test_ascii_boundary_detectors_cover_ordinary_matches(text: str) -> None:
+    """ASCII-boundary scans conservatively cover ordinary URL matches."""
+    ordinary_spans = _detect_domain_like_url_spans(text, DOMAIN_HOST_CANDIDATE_RE)
+    ordinary_ip_matches = IP_URL_RE.finditer(text)
+    ordinary_spans.extend(match.span() for match in ordinary_ip_matches)
+    ambiguous_spans = _detect_domain_like_url_spans(
+        text,
+        AMBIGUOUS_DOMAIN_HOST_CANDIDATE_RE,
+    )
+    ambiguous_ip_matches = AMBIGUOUS_IP_URL_RE.finditer(text)
+    ambiguous_spans.extend(match.span() for match in ambiguous_ip_matches)
+
+    for ordinary_start, ordinary_end in ordinary_spans:
+        ordinary_span_is_covered = False
+        for ambiguous_start, ambiguous_end in ambiguous_spans:
+            if ambiguous_start <= ordinary_start and ordinary_end <= ambiguous_end:
+                ordinary_span_is_covered = True
+                break
+        assert ordinary_span_is_covered  # noqa: S101
+
+
 def test_detect_urls_scales_linearly_for_invalid_domain_input() -> None:
     """Doubling invalid dotted input should not cause quadratic growth."""
     small_text = "a." * 2_000 + "-"
@@ -83,15 +122,1523 @@ def test_detect_urls_preserves_unicode_casefolded_domain() -> None:
     assert _detect_urls("Visit attacker.cK now") == ["attacker.cK"]  # noqa: S101
 
 
+def test_ambiguous_scanner_ignores_control_only_text() -> None:
+    """Control-only text does not become a URL candidate."""
+    assert _find_ambiguous_url_candidates("\t\n\r") == []  # noqa: S101
+
+
+@settings(max_examples=100)
+@given(
+    pairs=st.lists(
+        st.sampled_from([("(", ")"), ("[", "]"), ("{", "}"), ("<", ">")]),
+        max_size=50,
+    )
+)
+def test_closing_delimiter_scanner_accepts_generated_nested_pairs(
+    pairs: list[tuple[str, str]],
+) -> None:
+    """Properly nested generated delimiters have no unmatched offsets."""
+    openings = "".join(opening for opening, _ in pairs)
+    closings = "".join(closing for _, closing in reversed(pairs))
+    text = f"{openings}payload{closings}"
+
+    assert _mark_unmatched_closing_delimiters(text) is None  # noqa: S101
+
+
+def test_closing_delimiter_scanner_allocates_mask_for_mismatch() -> None:
+    """A mismatched closing delimiter is marked at its source offset."""
+    unmatched_mask = _mark_unmatched_closing_delimiters("([)]")
+
+    assert unmatched_mask is not None  # noqa: S101
+    assert list(unmatched_mask) == [0, 0, 1, 0]  # noqa: S101
+
+
+ASCII_URL_CONTROLS = pytest.mark.parametrize("control", ["\t", "\n", "\r"])
+
+_AMBIGUOUS_URL_BASES = (
+    ("http", "http://", "allowed.example/path_(x)"),
+    ("https", "https://", "allowed.example/path_(x)"),
+    ("ftp", "ftp://", "allowed.example/path_(x)"),
+    ("http", "http://", "[::1]/internal"),
+    ("data", "data:", "text/plain,hello"),
+    ("javascript", "javascript:", "alert(1)"),
+    ("vbscript", "vbscript:", "msgbox(1)"),
+    ("mailto", "mailto:", "user@allowed.example"),
+)
+_AMBIGUOUS_URL_BOUNDARIES = (
+    ("", ""),
+    ("Use ", " now"),
+    ("(", ")."),
+    ("[", "]"),
+)
+
+
+@st.composite
+def _ambiguous_url_cases(draw: DrawFn) -> tuple[str, str, str]:
+    """Generate ambiguous URLs with varied controls and boundaries.
+
+    Args:
+        draw: Hypothesis draw function for composing generated values.
+
+    Returns:
+        The normalized scheme, raw candidate, and surrounding source text.
+    """
+    scheme, scheme_prefix, payload = draw(st.sampled_from(_AMBIGUOUS_URL_BASES))
+    uppercase_flags = draw(
+        st.lists(
+            st.booleans(),
+            min_size=len(scheme_prefix),
+            max_size=len(scheme_prefix),
+        )
+    )
+    cased_scheme_prefix = "".join(
+        character.upper() if uppercase else character
+        for character, uppercase in zip(
+            scheme_prefix,
+            uppercase_flags,
+            strict=True,
+        )
+    )
+    base_candidate = cased_scheme_prefix + payload
+    control_position = draw(st.integers(min_value=1, max_value=len(base_candidate) - 1))
+    control_run = draw(st.text(alphabet="\t\n\r", min_size=1, max_size=32))
+    candidate = base_candidate[:control_position] + control_run + base_candidate[control_position:]
+    prefix, suffix = draw(st.sampled_from(_AMBIGUOUS_URL_BOUNDARIES))
+
+    return scheme, candidate, f"{prefix}{candidate}{suffix}"
+
+
+@st.composite
+def _delimiter_heavy_ambiguous_url_cases(draw: DrawFn) -> tuple[str, int]:
+    """Generate control-bearing URLs with parser-valid delimiters.
+
+    Args:
+        draw: Hypothesis draw function for composing generated values.
+
+    Returns:
+        The raw URL-like segment and the first inserted control offset.
+    """
+    scheme = draw(st.sampled_from([value[1] for value in _AMBIGUOUS_URL_BASES]))
+    body = draw(
+        st.text(
+            alphabet='abcXYZ019./:@?&#[](){}|^`\\<>"!;,-_+=',
+            max_size=80,
+        )
+    )
+    base_candidate = f"{scheme}{body}z"
+    control_position = draw(st.integers(min_value=1, max_value=len(base_candidate) - 1))
+    control_run = draw(st.text(alphabet="\t\n\r", min_size=1, max_size=8))
+    candidate = base_candidate[:control_position] + control_run + base_candidate[control_position:]
+
+    return candidate, control_position
+
+
+@st.composite
+def _scheme_less_ambiguous_url_cases(draw: DrawFn) -> str:
+    """Generate scheme-less domain and IP control insertions.
+
+    Args:
+        draw: Hypothesis draw function for composing generated values.
+
+    Returns:
+        A raw scheme-less URL containing an ASCII URL control run.
+    """
+    base_candidate = draw(
+        st.sampled_from(
+            [
+                "trusted.com",
+                "sub.trusted.example/path",
+                "192.168.1.12",
+                "192.168.1.12:8080/internal",
+            ]
+        )
+    )
+    control_position = draw(st.integers(min_value=1, max_value=len(base_candidate) - 1))
+    control_run = draw(st.text(alphabet="\t\n\r", min_size=1, max_size=16))
+
+    return base_candidate[:control_position] + control_run + base_candidate[control_position:]
+
+
+@st.composite
+def _ambiguous_cleanup_cases(draw: DrawFn) -> tuple[str, int]:
+    """Generate raw control-bearing candidates and protected lengths.
+
+    Args:
+        draw: Hypothesis draw function for composing generated values.
+
+    Returns:
+        A raw candidate containing an ASCII URL control and a prefix length
+        that cleanup must preserve.
+    """
+    alphabet = string.ascii_letters + string.digits + string.punctuation + " \t\n\r"
+    prefix = draw(st.text(alphabet=alphabet, max_size=50))
+    control = draw(st.sampled_from(["\t", "\n", "\r"]))
+    suffix = draw(st.text(alphabet=alphabet, max_size=50))
+    candidate = prefix + control + suffix
+    minimum_length = draw(st.integers(min_value=0, max_value=len(candidate)))
+
+    return candidate, minimum_length
+
+
+@settings(max_examples=200)
+@given(case=_ambiguous_cleanup_cases())
+def test_ambiguous_cleanup_preserves_generated_invariants(
+    case: tuple[str, int],
+) -> None:
+    """Cleanup remains prefix-preserving, control-bearing, and idempotent."""
+    candidate, minimum_length = case
+
+    cleaned = _clean_ambiguous_url_candidate(candidate, minimum_length)
+
+    assert candidate.startswith(cleaned)  # noqa: S101
+    assert len(cleaned) >= minimum_length  # noqa: S101
+    assert any(control in cleaned for control in "\t\n\r")  # noqa: S101
+    assert _clean_ambiguous_url_candidate(cleaned, minimum_length) == cleaned  # noqa: S101
+
+
 def test_detect_urls_deduplicates_scheme_and_domain() -> None:
     """Ensure detection removes trailing punctuation and avoids duplicate domains."""
-    text = "Visit https://example.com/, http://example.com/path, example.com should not duplicate, and 192.168.1.10:8080."
+    text = " ".join(
+        (
+            "Visit https://example.com/, http://example.com/path,",
+            "example.com should not duplicate, and 192.168.1.10:8080.",
+        )
+    )
     detected = _detect_urls(text)
 
     assert "https://example.com/" in detected  # noqa: S101
     assert "http://example.com/path" in detected  # noqa: S101
     assert "example.com" not in detected  # noqa: S101
     assert "192.168.1.10:8080" in detected  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+def test_detect_urls_preserves_control_obfuscated_http_scheme(control: str) -> None:
+    """Python-normalized scheme obfuscation must remain raw."""
+    candidate = f"htt{control}p://2130706433:8000/internal/credentials"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("candidate_template", "allowed_prefix"),
+    [
+        ("trusted.co{control}m", "trusted.co"),
+        ("192.168.1.1{control}2", "192.168.1.1"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_control_bearing_scheme_less_url(
+    control: str,
+    candidate_template: str,
+    allowed_prefix: str,
+) -> None:
+    """A scheme-less safe prefix cannot hide a normalized continuation."""
+    candidate = candidate_template.format(control=control)
+    config = URLConfig(url_allow_list=[allowed_prefix], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("candidate_template", "allowed_prefix"),
+    [
+        ("é{control}trusted.com", "trusted.com"),
+        ("é{control}trusted.co{control}m", "trusted.co"),
+        ("é{control}192.168.1.1{control}2", "192.168.1.1"),
+        ("a1{control}92.168.1.12", "92.168.1.12"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_raw_scheme_less_boundaries(
+    control: str,
+    candidate_template: str,
+    allowed_prefix: str,
+) -> None:
+    """Control-created boundaries survive scheme-less normalization."""
+    candidate = candidate_template.format(control=control)
+    config = URLConfig(
+        url_allow_list=[allowed_prefix],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@given(
+    prefix=st.text(alphabet=string.ascii_letters + string.digits, min_size=1, max_size=16),
+    control=st.sampled_from(["\t", "\n", "\r"]),
+    suffix=st.sampled_from(
+        [
+            "92.168.1.12",
+            "92.168.1.12:8080",
+            "92.168.1.12/internal/credentials",
+        ]
+    ),
+)
+def test_ambiguous_scanner_preserves_control_created_ip_boundaries(
+    prefix: str,
+    control: str,
+    suffix: str,
+) -> None:
+    """Raw IP boundaries remain visible when normalization joins a prefix."""
+    candidate = prefix + control + suffix
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert detected == [(candidate, (0, len(candidate)))]  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(prefix_length=st.integers(min_value=10_000, max_value=50_000))
+def test_ambiguous_scanner_handles_long_prefix_before_control_created_ip(
+    prefix_length: int,
+) -> None:
+    """Raw IP boundary fallback remains bounded for long joined prefixes."""
+    candidate = "a" * prefix_length + "\t92.168.1.12"
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert detected == [(candidate, (0, len(candidate)))]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("candidate_template", "expected_template", "allowed_prefix"),
+    [
+        ("étrusted.co{control}m", "trusted.co{control}m", "trusted.co"),
+        ("étrusted.c{control}K", "trusted.c{control}K", "trusted.cK"),
+        ("étrusted.ſ{control}ſ", "trusted.ſ{control}ſ", "trusted.ſſ"),
+        ("é192.168.1.1{control}2", "192.168.1.1{control}2", "192.168.1.1"),
+        ("_trusted.co{control}m", "trusted.co{control}m", "trusted.co"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_uses_ascii_boundaries_for_ambiguous_urls(
+    control: str,
+    candidate_template: str,
+    expected_template: str,
+    allowed_prefix: str,
+) -> None:
+    """Unicode word boundaries cannot suppress ambiguous URL detection."""
+    candidate = candidate_template.format(control=control)
+    expected = expected_template.format(control=control)
+    config = URLConfig(url_allow_list=[allowed_prefix], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [expected]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [expected]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{expected}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("host", ["trusted.com", "192.168.1.1"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_keeps_control_bearing_scheme_less_userinfo_prefix(
+    control: str,
+    host: str,
+) -> None:
+    """Controls in scheme-less userinfo remain part of the raw candidate."""
+    candidate = f"user{control}@{host}"
+    config = URLConfig(url_allow_list=[host], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_treats_leading_control_as_whitespace(control: str) -> None:
+    """A leading control remains a separator from a normal URL."""
+    candidate = "trusted.com"
+    config = URLConfig(url_allow_list=[candidate], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"{control}{candidate}", config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == [candidate]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_ignores_only_leading_control_prefix(control: str) -> None:
+    """An internal control remains ambiguous after a leading separator."""
+    candidate = f"é{control}trusted.com"
+    config = URLConfig(url_allow_list=["trusted.com"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"{control}{candidate}", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_merges_duplicate_shadow_boundaries(control: str) -> None:
+    """Shadow and ordinary matches produce one complete raw candidate."""
+    candidate = f"prefix/{control}trusted.com"
+    config = URLConfig(url_allow_list=["trusted.com"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("delimiter", ["[", "]", "\\", "<", ">", '"', "{", "}", "|", "^", "`"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_keeps_scheme_less_delimiter_continuation(
+    control: str,
+    delimiter: str,
+) -> None:
+    """A scheme-less delimiter cannot hide a later URL control."""
+    candidate = f"trusted.co{delimiter}{control}m"
+    config = URLConfig(url_allow_list=["trusted.co"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_does_not_bridge_scheme_less_prose() -> None:
+    """Scheme-less URLs do not absorb later prose containing controls."""
+    text = "See trusted.co for notes about user@example.com before\ta demo"
+    config = URLConfig(
+        url_allow_list=["trusted.co", "example.com"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == ["trusted.co", "example.com"]  # noqa: S101
+    assert result.info["allowed"] == ["trusted.co", "example.com"]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_separates_adjacent_scheme_less_candidates() -> None:
+    """A normal domain remains separate from an ambiguous neighbor."""
+    normal = "normal.example"
+    ambiguous = "trusted.co\tm"
+    config = URLConfig(
+        url_allow_list=[normal, "trusted.co"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=f"{normal},{ambiguous}", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous, normal]  # noqa: S101
+    assert result.info["allowed"] == [normal]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "text_template",
+    [
+        "[{normal}]({ambiguous})",
+        "[{ambiguous}]({normal})",
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_separates_mixed_markdown_candidates(
+    text_template: str,
+) -> None:
+    """Scheme-less normal and explicit ambiguous URLs stay independent."""
+    normal = "normal.example"
+    ambiguous = "http://trusted.co\tm"
+    config = URLConfig(
+        url_allow_list=[normal, "trusted.co"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(
+        ctx=None,
+        data=text_template.format(normal=normal, ambiguous=ambiguous),
+        config=config,
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous, normal]  # noqa: S101
+    assert result.info["allowed"] == [normal]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_trims_scheme_less_markdown_boundary(control: str) -> None:
+    """A scheme-less link label excludes adjacent Markdown syntax."""
+    ambiguous = f"trusted.co{control}m"
+    normal = "normal.example"
+    text = f"[{ambiguous}](destination)[{normal}](destination)"
+    config = URLConfig(
+        url_allow_list=["trusted.co", normal],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous, normal]  # noqa: S101
+    assert result.info["allowed"] == [normal]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{ambiguous}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("destination_control", ["\t", "\n", "\r"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_trims_markdown_before_later_control(
+    control: str,
+    destination_control: str,
+) -> None:
+    """A later destination control cannot extend the link-label candidate."""
+    ambiguous = f"trusted.co{control}m"
+    text = f"[{ambiguous}](destination{destination_control}text)"
+    config = URLConfig(
+        url_allow_list=["trusted.co"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{ambiguous}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_explicit_markdown_destination(
+    control: str,
+) -> None:
+    """Trimming a scheme-less label preserves the destination URL shape."""
+    ambiguous = f"trusted.co{control}m"
+    normal = "https://normal.example/docs"
+    text = f"[{ambiguous}]({normal})"
+    config = URLConfig(
+        url_allow_list=["trusted.co", normal],
+        allowed_schemes={"http", "https"},
+    )
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [normal, ambiguous]  # noqa: S101
+    assert result.info["allowed"] == [normal]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{ambiguous}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("opening", "closing"),
+    [
+        ("(", ")"),
+        ("[", "]"),
+        ("<", ">"),
+        ("{", "}"),
+        ('"', '"'),
+        ("`", "`"),
+        ("|", "|"),
+        ("^", "^"),
+        ("\\", "\\"),
+    ],
+)
+@pytest.mark.parametrize("wrapper_width", [1, 2])
+@pytest.mark.asyncio
+async def test_urls_guardrail_trims_unmatched_wrapping_delimiter(
+    control: str,
+    opening: str,
+    closing: str,
+    wrapper_width: int,
+) -> None:
+    """A wrapping prose delimiter is excluded from the raw candidate."""
+    ambiguous = f"trusted.co{control}m"
+    config = URLConfig(
+        url_allow_list=["trusted.co"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(
+        ctx=None,
+        data=f"{opening * wrapper_width}{ambiguous}{closing * wrapper_width}",
+        config=config,
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{ambiguous}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("delimiter", ["[", "{", "<"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_trims_unmatched_trailing_opening_delimiter(
+    control: str,
+    delimiter: str,
+) -> None:
+    """An unmatched trailing opener is excluded from the raw candidate."""
+    ambiguous = f"trusted.co{control}m"
+    config = URLConfig(
+        url_allow_list=["trusted.co"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=ambiguous + delimiter, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{ambiguous}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("prefix_delimiter", "trailing_delimiter"),
+    [("]", "["), ("}", "{"), (">", "<")],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_does_not_pair_inverted_delimiters(
+    control: str,
+    prefix_delimiter: str,
+    trailing_delimiter: str,
+) -> None:
+    """Oppositely ordered delimiters cannot retain a trailing boundary."""
+    ambiguous = f"trusted.co{prefix_delimiter}{control}m"
+    config = URLConfig(
+        url_allow_list=["trusted.co"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(
+        ctx=None,
+        data=ambiguous + trailing_delimiter,
+        config=config,
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{ambiguous}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    "boundary",
+    ["[", "{", "<", '"', "`", "|", "^", "\\", ")", "]", "}", ">"],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_stops_at_post_control_hard_boundary(
+    control: str,
+    boundary: str,
+) -> None:
+    """Adjacent text after a hard boundary stays outside the candidate."""
+    ambiguous = f"trusted.co{control}m"
+    config = URLConfig(
+        url_allow_list=["trusted.co", "adjacent.example"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(
+        ctx=None,
+        data=f"{ambiguous}{boundary}adjacent.example",
+        config=config,
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous, "adjacent.example"]  # noqa: S101
+    assert result.info["allowed"] == ["adjacent.example"]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+    assert result.info["blocked_reasons"][0] == f"{ambiguous}: {AMBIGUOUS_URL_REASON}"  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_matched_ipv6_delimiters(control: str) -> None:
+    """A control-bearing IPv6 URL retains its matched address brackets."""
+    candidate = f"http://[::{control}1]"
+    config = URLConfig(
+        url_allow_list=["[::1]"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_keeps_unconfirmed_scheme_less_markdown_boundary(
+    control: str,
+) -> None:
+    """A Markdown-like delimiter before a control remains in the candidate."""
+    candidate = f"trusted.example/safe](junk{control}admin"
+    config = URLConfig(
+        url_allow_list=["trusted.example/safe"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_final_lf_after_punctuation() -> None:
+    """Cleanup cannot remove a final LF from an ambiguous candidate."""
+    candidate = "http://trusted.example!\n"
+    config = URLConfig(
+        url_allow_list=["trusted.example"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_scheme_less_userinfo_candidate(
+    control: str,
+) -> None:
+    """Scheme-less userinfo remains one raw ambiguous candidate."""
+    candidate = f"trusted.com{control}@evil.example/path"
+    config = URLConfig(
+        url_allow_list=["trusted.com", "evil.example"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_configured_scheme_obfuscation(
+    control: str,
+) -> None:
+    """Configured hierarchical schemes cannot hide controls."""
+    candidate = f"cust{control}om://trusted.example/path"
+    config = URLConfig(
+        url_allow_list=["trusted.example"],
+        allowed_schemes={"custom"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_configured_hostless_scheme_obfuscation(
+    control: str,
+) -> None:
+    """Configured hostless schemes cannot hide controls."""
+    candidate = f"cust{control}om:user@trusted.example"
+    config = URLConfig(
+        url_allow_list=["trusted.example"],
+        allowed_schemes={"custom"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_long_configured_scheme_obfuscation() -> None:
+    """Arbitrarily long configured schemes remain fail-closed."""
+    scheme = "a" * 4_096
+    candidate = f"{scheme[:2048]}\t{scheme[2048:]}://trusted.example/path"
+    config = URLConfig(
+        url_allow_list=["trusted.example"],
+        allowed_schemes={scheme},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+def test_urls_guardrail_scales_linearly_for_long_configured_scheme() -> None:
+    """Public scanning avoids repeated long configured-scheme matches."""
+
+    def scan_scheme(scheme_length: int) -> None:
+        scheme = "a" * scheme_length
+        text = scheme + "\tvalue"
+        config = URLConfig(allowed_schemes={scheme})
+
+        result = asyncio.run(urls(ctx=None, data=text, config=config))
+
+        assert result.tripwire_triggered is False  # noqa: S101
+        assert result.info["detected"] == []  # noqa: S101
+
+    small_duration = median(repeat(lambda: scan_scheme(4_000), number=1, repeat=5))
+    large_duration = median(repeat(lambda: scan_scheme(8_000), number=1, repeat=5))
+
+    assert large_duration < small_duration * 3  # noqa: S101
+
+
+def test_urls_guardrail_scales_linearly_for_many_configured_schemes() -> None:
+    """Public scanning avoids sorting the configured-scheme collection."""
+
+    def build_config(scheme_count: int) -> URLConfig:
+        schemes = {f"s{index:08x}" for index in range(scheme_count)}
+        schemes.update(("data", "https"))
+        return URLConfig(allowed_schemes=schemes)
+
+    small_config = build_config(5_000)
+    large_config = build_config(10_000)
+
+    def scan_config(config: URLConfig) -> None:
+        result = asyncio.run(urls(ctx=None, data="plain\ttext", config=config))
+
+        assert result.tripwire_triggered is False  # noqa: S101
+        assert result.info["detected"] == []  # noqa: S101
+
+    small_duration = median(repeat(lambda: scan_config(small_config), number=1, repeat=5))
+    large_duration = median(repeat(lambda: scan_config(large_config), number=1, repeat=5))
+
+    assert large_duration < small_duration * 3  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_mailto_scheme_obfuscation(
+    control: str,
+) -> None:
+    """Mailto obfuscation fails closed even when mailto is disallowed."""
+    candidate = f"mail{control}to:user@trusted.example"
+    config = URLConfig(
+        url_allow_list=["trusted.example"],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("hard_boundary", ['"', "<", ">"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_obfuscated_scheme_before_hard_boundary(
+    control: str,
+    hard_boundary: str,
+) -> None:
+    """A hard boundary cannot hide the body of an obfuscated scheme."""
+    candidate = f"htt{control}p://{hard_boundary}@trusted.example/path"
+    config = URLConfig(url_allow_list=["trusted.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("prefix", ["+", "-", ".", "a", "0"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_ambiguous_scheme_after_prefix(
+    control: str,
+    prefix: str,
+) -> None:
+    """Ordinary scheme boundaries must not hide an ambiguous URL."""
+    candidate = f"https://trusted.co{control}m"
+    config = URLConfig(url_allow_list=["trusted.co"], allowed_schemes={"https"})
+
+    result = await urls(ctx=None, data=prefix + candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("scheme", "split_at", "payload"),
+    [
+        ("data", 2, "text/plain,hello"),
+        ("javascript", 4, "alert(1)"),
+        ("vbscript", 2, "msgbox(1)"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_control_obfuscated_special_scheme(
+    control: str,
+    scheme: str,
+    split_at: int,
+    payload: str,
+) -> None:
+    """Special schemes normalized by urllib.parse must fail closed."""
+    candidate = f"{scheme[:split_at]}{control}{scheme[split_at:]}:{payload}"
+    config = URLConfig(allowed_schemes={scheme})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("scheme", "split_at", "suffix"),
+    [
+        ("data", 2, ""),
+        ("data", 2, ";"),
+        ("javascript", 4, ""),
+        ("javascript", 4, "!"),
+        ("vbscript", 2, ""),
+        ("vbscript", 2, "..."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_obfuscated_hostless_scheme_delimiter(
+    control: str,
+    scheme: str,
+    split_at: int,
+    suffix: str,
+) -> None:
+    """Candidate cleanup must preserve the structural scheme colon."""
+    raw_scheme = f"{scheme[:split_at]}{control}{scheme[split_at:]}:"
+    config = URLConfig(allowed_schemes={scheme})
+
+    result = await urls(ctx=None, data=raw_scheme + suffix, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [raw_scheme]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [raw_scheme]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{raw_scheme}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "javaſcript:\talert(1)",
+        "javascrİpt:\nalert(1)",
+        "vbſcript:\rmsgbox(1)",
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_ignores_non_ascii_scheme_confusables(text: str) -> None:
+    """Unicode casefolding must not create a Python URL scheme."""
+    result = await urls(ctx=None, data=text, config=URLConfig())
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == []  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    "outer_scheme",
+    ["http://", "https://", "ftp://", "data:", "javascript:", "vbscript:"],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_nested_scheme_after_control(
+    control: str,
+    outer_scheme: str,
+) -> None:
+    """A nested allowed URL must not hide a control-bearing outer scheme."""
+    candidate = f"{outer_scheme}{control}https://trusted.example/path"
+    config = URLConfig(url_allow_list=["trusted.example"], allowed_schemes={"https"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_nested_scheme_after_path_control(control: str) -> None:
+    """Path text before a control must remain joined to a nested scheme."""
+    outer_url = "http://outer.example/foo"
+    inner_url = "https://inner.example"
+    candidate = f"{outer_url}{control}{inner_url}"
+    config = URLConfig(
+        url_allow_list=[outer_url, inner_url],
+        allowed_schemes={"http", "https"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    "candidate_template",
+    [
+        "http://[::1]/inter{control}nal",
+        "htt{control}p://[::1]/internal",
+        "http://{control}[::1]/internal",
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_control_bearing_ipv6_url(
+    control: str,
+    candidate_template: str,
+) -> None:
+    """Control-bearing IPv6 URLs must not evade scheme detection."""
+    candidate = candidate_template.format(control=control)
+    config = URLConfig(url_allow_list=["[::1]"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+def test_detect_urls_preserves_controls_in_scheme_separator(control: str) -> None:
+    """Python-normalized scheme separators must remain raw."""
+    candidate = f"http:{control}//2130706433:8000/internal/credentials"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+def test_detect_urls_preserves_controls_in_canonical_url(control: str) -> None:
+    """Controls inside a canonical URL must remain raw."""
+    candidate = f"http://2130706433:8000/inter{control}nal/credentials"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+def test_detect_urls_preserves_balanced_candidate_delimiters(control: str) -> None:
+    """Balanced URL delimiters remain while sentence punctuation is removed."""
+    candidate = f"http://allowed.example/pa{control}th_(x)"
+
+    detected = _detect_urls(f"Visit ({candidate}).")
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("delimiter", ["[", "]", "\\", "<", ">", '"', "{", "}", "|", "^", "`"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_control_after_excluded_delimiter(
+    control: str,
+    delimiter: str,
+) -> None:
+    """An excluded delimiter must not hide a later URL control."""
+    candidate = f"http://trusted.example/safe{delimiter}{control}admin"
+    config = URLConfig(
+        url_allow_list=["http://trusted.example/safe"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@pytest.mark.parametrize("whitespace", ["\u0085", "\u00a0", "\u2003", "\u2028", "\u2029"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_stops_before_non_control_whitespace(whitespace: str) -> None:
+    """Unrelated controls after Unicode whitespace remain outside the URL."""
+    url = "http://allowed.example"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"{url}{whitespace}Notes\tvalue", config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize(
+    ("whitespace", "userinfo"),
+    [
+        (" ", ""),
+        ("\v", ":password"),
+        ("\f", "user"),
+        ("\u0085", "user:password"),
+        ("\u00a0", "first last"),
+        ("\u2003", "user"),
+        ("\u2028", ""),
+        ("\u2029", ":password"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_urls_guardrail_bridges_whitespace_before_userinfo_host(
+    control: str,
+    whitespace: str,
+    userinfo: str,
+) -> None:
+    """Whitespace before userinfo cannot hide a control-bearing host."""
+    candidate = f"http://allowed.example{whitespace}{userinfo}@2130706433{control}/internal"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_bridges_nested_scheme_userinfo_host(control: str) -> None:
+    """An outer path must not hide an inner scheme's userinfo host."""
+    outer_url = "http://outer.example/path"
+    inner_url = f"http://allowed.example user@2130706433{control}/internal"
+    candidate = outer_url + inner_url
+    config = URLConfig(
+        url_allow_list=["outer.example", "allowed.example"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_uses_last_userinfo_host(control: str) -> None:
+    """Repeated userinfo markers cannot hide the final parsed host."""
+    candidate = " ".join(
+        (
+            "http://allowed.example first@intermediate.example",
+            f"second@2130706433{control}/internal",
+        )
+    )
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+def test_detect_urls_preserves_controls_after_path_separator(control: str) -> None:
+    """A standalone URL may continue after a controlled separator."""
+    candidate = f"http://2130706433:8000/{control}internal/credentials"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+def test_detect_urls_handles_long_control_run() -> None:
+    """A long control run is consumed as one URL candidate token."""
+    candidate = "http://allowed.example/" + "\n" * 30_000 + "internal"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+def test_detect_urls_skips_suffix_after_unmatched_closing_boundary() -> None:
+    """An unmatched closing boundary prevents scanning an irrelevant suffix."""
+    candidate = "trusted.co\tm"
+    text = candidate + ")" + "(" * 30_000
+
+    detected = _detect_urls(text)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@settings(max_examples=75)
+@given(case=_ambiguous_url_cases())
+def test_urls_guardrail_blocks_generated_ambiguous_candidates(
+    case: tuple[str, str, str],
+) -> None:
+    """Generated ambiguous URLs remain raw and fail closed."""
+    scheme, candidate, text = case
+    config = URLConfig(
+        url_allow_list=["allowed.example", "[::1]"],
+        allowed_schemes={scheme},
+    )
+
+    detected = _detect_urls(text)
+    result = asyncio.run(urls(ctx=None, data=text, config=config))
+
+    assert detected == [candidate]  # noqa: S101
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [  # noqa: S101
+        f"{candidate}: {AMBIGUOUS_URL_REASON}"
+    ]
+
+
+@settings(max_examples=100)
+@given(case=_delimiter_heavy_ambiguous_url_cases())
+def test_ambiguous_scanner_covers_generated_control_offset(
+    case: tuple[str, int],
+) -> None:
+    """Delimiter combinations cannot hide an inserted URL control."""
+    candidate, control_position = case
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    inserted_control_is_covered = False
+    for raw_candidate, (start, end) in detected:
+        has_url_control = any(control in raw_candidate for control in "\t\n\r")
+        if start <= control_position < end and has_url_control:
+            inserted_control_is_covered = True
+            break
+    assert inserted_control_is_covered  # noqa: S101
+    assert all(  # noqa: S101
+        any(control in raw_candidate for control in "\t\n\r") for raw_candidate, _ in detected
+    )
+
+
+@settings(max_examples=100)
+@given(candidate=_scheme_less_ambiguous_url_cases())
+def test_ambiguous_scanner_preserves_generated_scheme_less_candidate(
+    candidate: str,
+) -> None:
+    """Generated scheme-less candidates remain raw and ambiguous."""
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert detected == [(candidate, (0, len(candidate)))]  # noqa: S101
+
+
+@settings(max_examples=100)
+@given(
+    candidate=_scheme_less_ambiguous_url_cases(),
+    destination=st.text(
+        alphabet=string.ascii_letters + string.digits + "_-/",
+        min_size=1,
+        max_size=30,
+    ),
+    destination_control=st.sampled_from(["", "\t", "\n", "\r"]),
+)
+def test_ambiguous_scanner_trims_generated_markdown_boundary(
+    candidate: str,
+    destination: str,
+    destination_control: str,
+) -> None:
+    """Generated scheme-less link labels exclude Markdown syntax."""
+    text = f"[{candidate}]({destination}{destination_control}text)"
+
+    detected = _find_ambiguous_url_candidates(text)
+
+    assert detected[0] == (candidate, (1, len(candidate) + 1))  # noqa: S101
+
+
+@settings(max_examples=100)
+@given(
+    candidate=_scheme_less_ambiguous_url_cases(),
+    trailing_boundaries=st.text(
+        alphabet='.,;:!?)]}>"`|^\\',
+        min_size=1,
+        max_size=16,
+    ),
+)
+def test_ambiguous_scanner_trims_generated_trailing_boundaries(
+    candidate: str,
+    trailing_boundaries: str,
+) -> None:
+    """Mixed generated trailing boundaries remain outside the span."""
+    text = candidate + trailing_boundaries
+
+    detected = _find_ambiguous_url_candidates(text)
+
+    assert detected == [(candidate, (0, len(candidate)))]  # noqa: S101
+
+
+@settings(max_examples=100)
+@given(
+    prefix=st.sampled_from(["é", "١", "_", "é_name@"]),
+    base_candidate=st.sampled_from(["trusted.com", "trusted.cK", "trusted.ſſ", "192.168.1.12"]),
+    control=st.sampled_from(["\t", "\n", "\r"]),
+    control_position=st.integers(min_value=1, max_value=8),
+)
+def test_ambiguous_scanner_handles_non_ascii_scheme_less_boundaries(
+    prefix: str,
+    base_candidate: str,
+    control: str,
+    control_position: int,
+) -> None:
+    """Non-ASCII boundaries cannot hide a control-bearing URL suffix."""
+    insertion = min(control_position, len(base_candidate) - 1)
+    controlled_candidate = base_candidate[:insertion] + control + base_candidate[insertion:]
+    text = prefix + controlled_candidate
+
+    detected = _find_ambiguous_url_candidates(text)
+
+    candidate_is_covered = False
+    for raw_candidate, (start, end) in detected:
+        raw_span_is_preserved = raw_candidate == text[start:end]
+        if raw_span_is_preserved and control in raw_candidate:
+            candidate_is_covered = controlled_candidate in raw_candidate
+            if candidate_is_covered:
+                break
+    assert candidate_is_covered  # noqa: S101
+
+
+@settings(max_examples=12, deadline=timedelta(milliseconds=500))
+@given(
+    control=st.sampled_from(["\t", "\n", "\r"]),
+    run_length=st.integers(min_value=10_000, max_value=50_000),
+)
+def test_detect_urls_handles_generated_long_control_runs(
+    control: str,
+    run_length: int,
+) -> None:
+    """Long generated control runs are detected within a bounded time."""
+    candidate = "http://allowed.example/" + control * run_length + "internal"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@settings(max_examples=12, deadline=timedelta(milliseconds=500))
+@given(
+    control=st.sampled_from(["\t", "\n", "\r"]),
+    run_length=st.integers(min_value=10_000, max_value=50_000),
+)
+def test_detect_urls_handles_long_control_runs_before_nested_scheme(
+    control: str,
+    run_length: int,
+) -> None:
+    """Nested schemes after long control runs are detected in bounded time."""
+    candidate = "javascript:" + control * run_length + "https://trusted.example/path"
+
+    detected = _detect_urls(candidate)
+
+    assert detected == [candidate]  # noqa: S101
+
+
+@settings(max_examples=12, deadline=timedelta(milliseconds=500))
+@given(
+    control=st.sampled_from(["\t", "\n", "\r"]),
+    fragment_count=st.integers(min_value=1_000, max_value=10_000),
+)
+def test_ambiguous_scanner_skips_large_control_free_segments(
+    control: str,
+    fragment_count: int,
+) -> None:
+    """Unrelated controls do not cause repeated scans of prior segments."""
+    control_free_segment = "http://allowed.example[" * fragment_count
+    text = f"{control_free_segment} prose{control}value"
+
+    candidates = _find_ambiguous_url_candidates(text)
+
+    assert candidates == []  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(suffix_length=st.integers(min_value=10_000, max_value=50_000))
+def test_ambiguous_scanner_skips_suffix_after_last_control(
+    suffix_length: int,
+) -> None:
+    """A large control-free suffix is skipped after the last control."""
+    text = "plain\tprose " + "x" * suffix_length
+
+    candidates = _find_ambiguous_url_candidates(text)
+
+    assert candidates == []  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(word_count=st.integers(min_value=1_000, max_value=10_000))
+def test_ambiguous_scanner_handles_long_userinfo_in_linear_time(
+    word_count: int,
+) -> None:
+    """Whitespace-bearing userinfo is scanned within a bounded time."""
+    candidate = "http://allowed.example " + "user " * word_count + "name@2130706433\t/internal"
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert detected == [(candidate, (0, len(candidate)))]  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(authority_count=st.integers(min_value=1_000, max_value=10_000))
+def test_ambiguous_scanner_handles_repeated_authorities_in_linear_time(
+    authority_count: int,
+) -> None:
+    """Repeated whitespace userinfo authorities remain linear."""
+    candidate = "http://a user@" * authority_count + "2130706433\t/internal"
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert detected == [(candidate, (0, len(candidate)))]  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(fragment_count=st.integers(min_value=1_000, max_value=10_000))
+def test_ambiguous_scanner_handles_scheme_less_prose_in_linear_time(
+    fragment_count: int,
+) -> None:
+    """Repeated scheme-less prose boundaries remain linear."""
+    text = "trusted.co word " * fragment_count + "tail\tvalue"
+
+    detected = _find_ambiguous_url_candidates(text)
+
+    assert detected == []  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(candidate_count=st.integers(min_value=1_000, max_value=10_000))
+def test_ambiguous_scanner_handles_many_scheme_less_candidates(
+    candidate_count: int,
+) -> None:
+    """Many scheme-less candidates are collected within a bounded time."""
+    candidate = "a.co\tm," * candidate_count + "z.co\tm"
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert len(detected) == candidate_count + 1  # noqa: S101
+    assert detected[0][0] == "a.co\tm"  # noqa: S101
+    assert detected[-1][0] == "z.co\tm"  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(candidate_count=st.integers(min_value=1_000, max_value=10_000))
+def test_ambiguous_scanner_handles_many_non_ascii_boundaries(
+    candidate_count: int,
+) -> None:
+    """Unicode-prefixed scheme-less candidates remain linear."""
+    candidate = "étrusted.co\tm " * candidate_count
+
+    detected = _find_ambiguous_url_candidates(candidate)
+
+    assert len(detected) == candidate_count  # noqa: S101
+    assert all(raw_candidate == "trusted.co\tm" for raw_candidate, _ in detected)  # noqa: S101
+
+
+@settings(max_examples=8, deadline=timedelta(milliseconds=500))
+@given(candidate_count=st.integers(min_value=1_000, max_value=5_000))
+def test_ambiguous_scanner_handles_many_markdown_boundaries(
+    candidate_count: int,
+) -> None:
+    """Markdown cleanup with later controls remains linear."""
+    text = "[trusted.co\tm](destination\ntext) " * candidate_count
+
+    detected = _find_ambiguous_url_candidates(text)
+
+    assert len(detected) == candidate_count  # noqa: S101
+    assert all(raw_candidate == "trusted.co\tm" for raw_candidate, _ in detected)  # noqa: S101
 
 
 def test_validate_url_security_blocks_bad_scheme() -> None:
@@ -227,6 +1774,253 @@ async def test_urls_guardrail_reports_allowed_and_blocked() -> None:
     assert "https://sub.example.com" in result.info["blocked"]  # noqa: S101
     assert any("Blocked scheme" in reason for reason in result.info["blocked_reasons"])  # noqa: S101
     assert any("Not in allow list" in reason for reason in result.info["blocked_reasons"])  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_raw_control_obfuscated_scheme(control: str) -> None:
+    """Scheme controls interpreted by urllib.parse must fail closed."""
+    candidate = f"htt{control}p://2130706433:8000/internal/credentials"
+    config = URLConfig(url_allow_list=["2130706433"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_allowlisted_host_before_control_userinfo(control: str) -> None:
+    """A safe-looking host prefix must not hide decimal loopback userinfo."""
+    candidate = f"http://allowed.example{control}@2130706433:8000/internal/credentials"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_controls_in_canonical_url(control: str) -> None:
+    """Canonical schemes do not make control-bearing URLs safe."""
+    candidate = f"http://2130706433:8000/inter{control}nal/credentials"
+    config = URLConfig(url_allow_list=["2130706433"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_controls_inside_allowlisted_path(control: str) -> None:
+    """A safe path prefix must not hide a control-bearing continuation."""
+    candidate = f"http://allowed.example/pa{control}th"
+    config = URLConfig(
+        url_allow_list=["http://allowed.example/pa"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.parametrize("continuation", ["th", "Th"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_embedded_controls_inside_allowlisted_path(
+    control: str,
+    continuation: str,
+) -> None:
+    """Surrounding prose must not hide a control-bearing URL path."""
+    candidate = f"http://allowed.example/pa{control}{continuation}"
+    config = URLConfig(
+        url_allow_list=["http://allowed.example/pa"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=f"Use {candidate} now", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_embedded_controls_after_path_separator(control: str) -> None:
+    """A line break after a slash may still continue the URL path."""
+    candidate = f"http://allowed.example/{control}internal"
+    config = URLConfig(
+        url_allow_list=["http://allowed.example/"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=f"Use {candidate} now", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_controls_continuing_allowlisted_authority(
+    control: str,
+) -> None:
+    """A safe host prefix must not hide an authority continuation."""
+    candidate = f"http://allowed.example{control}.evil/path"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"Use {candidate} now", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_plain_standalone_authority_continuation(control: str) -> None:
+    """A standalone host continuation cannot be treated as prose."""
+    candidate = f"http://allowed.exa{control}mple"
+    config = URLConfig(url_allow_list=["allowed.exa"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_classifies_normal_and_ambiguous_urls_independently() -> None:
+    """Normal URLs stay allowed while raw ambiguous candidates are blocked."""
+    ambiguous = "http://allowed.example\t@2130706433:8000/internal/credentials"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+    text = f"Normal http://allowed.example/docs and ambiguous {ambiguous}"
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.info["detected"] == [ambiguous, "http://allowed.example/docs"]  # noqa: S101
+    assert result.info["allowed"] == ["http://allowed.example/docs"]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_keeps_markdown_adjacent_url_independent() -> None:
+    """A closing Markdown bracket remains a URL candidate boundary."""
+    ambiguous = "http://allowed.example/pa\tth"
+    normal = "http://allowed.example/docs"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"[{ambiguous}]({normal})", config=config)
+
+    assert result.info["detected"] == [ambiguous, normal]  # noqa: S101
+    assert result.info["allowed"] == [normal]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_does_not_trust_unconfirmed_markdown_boundary(
+    control: str,
+) -> None:
+    """A Markdown-like delimiter cannot hide a later URL control."""
+    candidate = f"http://trusted.example/safe](junk{control}admin"
+    config = URLConfig(
+        url_allow_list=["http://trusted.example/safe"],
+        allowed_schemes={"http"},
+    )
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+    assert result.info["blocked_reasons"] == [f"{candidate}: {AMBIGUOUS_URL_REASON}"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_allows_benign_multiline_prose_without_urls() -> None:
+    """Control characters in prose alone must not trigger URL filtering."""
+    result = await urls(
+        ctx=None,
+        data="First line\nSecond line\r\nThird\tcolumn",
+        config=URLConfig(),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == []  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.parametrize("control", ["\n", "\r", "\r\n"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_url_followed_by_prose_line(control: str) -> None:
+    """A URL-like span crossing a line break must fail closed."""
+    candidate = f"http://allowed.example/{control}Next"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"Visit {candidate} paragraph", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@ASCII_URL_CONTROLS
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_control_joined_urls(control: str) -> None:
+    """A control followed by another scheme remains one raw candidate."""
+    first_url = "http://allowed.example/"
+    second_url = "http://allowed.example/docs"
+    config = URLConfig(url_allow_list=["allowed.example"], allowed_schemes={"http"})
+    candidate = f"{first_url}{control}{second_url}"
+
+    result = await urls(ctx=None, data=candidate, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
+
+
+@pytest.mark.parametrize("control", ["\n", "\r", "\r\n"])
+@pytest.mark.asyncio
+async def test_urls_guardrail_blocks_single_label_host_crossing_line_break(control: str) -> None:
+    """A single-label host crossing a line break must fail closed."""
+    candidate = f"http://intranet{control}next"
+    config = URLConfig(url_allow_list=["intranet"], allowed_schemes={"http"})
+
+    result = await urls(ctx=None, data=f"Visit {candidate} paragraph", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [candidate]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [candidate]  # noqa: S101
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fail closed when URL-like candidates contain ASCII TAB, LF, or CR characters.
- Preserve ambiguous candidates exactly as detected and report a stable block reason.
- Keep normal URLs independently classified when mixed with ambiguous candidates.
- Preserve existing behavior for benign multiline prose and canonical URLs.

## Problem

The URL Filter previously detected only contiguous URL scheme spellings. ASCII control characters could therefore cause URL-like input to evade detection or make the detector validate only a safe-looking prefix.

Downstream URL parsers may interpret the original value differently. For example, an allowlisted host prefix followed by a control character and `@` can become userinfo, leaving a decimal IPv4 value as the effective host.

## Solution

The URL Filter now performs a scoped pre-scan for control-bearing candidates using its supported schemes:

- HTTP and HTTPS
- FTP
- Data URLs
- JavaScript URLs
- VBScript URLs

Ambiguous candidates are blocked before parsing or allow-list evaluation with the reason:

`Ambiguous URL containing ASCII control characters`

The detection logic also:

- handles control characters within schemes, separators, authorities, paths, and special schemes;
- supports bracketed IPv6 authorities;
- preserves balanced URL delimiters and raw control characters;
- avoids consuming adjacent Markdown URLs;
- keeps newline-separated URLs independent when a new recognized scheme begins; and
- does not reject multiline prose without URL-like candidates.

The public result shape and configuration remain unchanged.

## Testing

Coverage includes:

- TAB, LF, and CR variants;
- scheme obfuscation supported by Python parsing;
- allowlisted-host/userinfo/decimal-IPv4 inputs;
- controls in canonical URLs and paths;
- HTTP, HTTPS, FTP, data, JavaScript, and VBScript schemes;
- bracketed IPv6 URLs;
- balanced punctuation and Markdown boundaries;
- mixed normal and ambiguous URLs; and
- benign multiline negative cases.
