### PR TITLE
fix: harden secret detection in exempt tokens

### DIFF
--- a/src/guardrails/checks/text/secret_keys.py
+++ b/src/guardrails/checks/text/secret_keys.py
@@ -42,10 +42,19 @@ from __future__ import annotations
 
 import math
 import re
+from collections.abc import Iterator
+from heapq import merge
 from typing import Any, TypedDict
+from urllib.parse import ParseResult, unquote_to_bytes, urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from guardrails.checks.text.urls import (  # noqa: PLC2701
+    _ADJACENT_SCHEME_URL_BOUNDARIES,
+    _detect_domain_like_url_spans,
+    _detect_ip_url_spans,
+    _detect_urls,
+)
 from guardrails.registry import default_spec_registry
 from guardrails.spec import GuardrailSpecMetadata
 from guardrails.types import GuardrailResult
@@ -79,6 +88,35 @@ COMMON_KEY_PREFIXES = (
     "SHA:",
     "Bearer ",
 )
+
+
+_EMBEDDED_KEY_PREFIXES = (
+    "sk-",
+    "sk_",
+    "ghp_",
+    "xoxb-",
+    "xoxp-",
+    "SG.",
+    "hf_",
+)
+_EMBEDDED_OWNER_PREFIXES = (*_EMBEDDED_KEY_PREFIXES, "AKIA")
+_AWS_ACCESS_KEY_ID_RE = re.compile(r"AKIA[A-Z0-9]{16}\Z")
+_HTTP_SCHEME_RE = re.compile(r"https?://", re.IGNORECASE)
+_EXPLICIT_URL_SCHEME_RE = re.compile(
+    r"(?:https?|ftp)://|(?:data|javascript|vbscript):",
+    re.IGNORECASE,
+)
+_URL_SHAPED_SCHEME_RE = re.compile(
+    r"[a-z][a-z0-9+.-]*:/",
+    re.IGNORECASE,
+)
+_ASCII_SCHEME_START_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+_ASCII_SCHEME_CHARACTERS = _ASCII_SCHEME_START_CHARACTERS | frozenset("0123456789+.-")
+_HOSTLESS_URL_SCHEMES = frozenset(("data", "javascript", "mailto", "vbscript"))
+_NESTED_URL_VALUE_BOUNDARIES = _ADJACENT_SCHEME_URL_BOUNDARIES | frozenset(("/", "\\", "#", "&", "=", "@"))
+_STRUCTURAL_URL_SHAPE_BOUNDARIES = _ADJACENT_SCHEME_URL_BOUNDARIES | frozenset("=")
+_MAX_EXEMPT_CONTAINER_LENGTH = 64 * 1024
+
 
 # Define allowed file extensions
 ALLOWED_EXTENSIONS = (
@@ -259,7 +297,13 @@ def _contains_allowed_pattern(text: str) -> bool:
     return False
 
 
-def _is_secret_candidate(s: str, cfg: SecretCfg, custom_regex: list[str] | None = None) -> bool:
+def _is_secret_candidate(
+    s: str,
+    cfg: SecretCfg,
+    custom_regex: list[str] | None = None,
+    *,
+    allow_pattern_exemption: bool = True,
+) -> bool:
     """Check if a string is a secret key using the specified criteria.
 
     Skips candidates matching allowed patterns (when strict_mode=False),
@@ -270,6 +314,8 @@ def _is_secret_candidate(s: str, cfg: SecretCfg, custom_regex: list[str] | None 
         s (str): String to analyze.
         cfg (SecretCfg): Detection configuration.
         custom_regex (Optional[List[str]]): List of custom regex patterns to check.
+        allow_pattern_exemption: Whether URL and file exemptions may suppress
+            this candidate.
 
     Returns:
         bool: True if the string is a secret key; otherwise False.
@@ -280,7 +326,7 @@ def _is_secret_candidate(s: str, cfg: SecretCfg, custom_regex: list[str] | None 
             if re.match(pattern, s):
                 return True
 
-    if not cfg.get("strict_mode", False) and _contains_allowed_pattern(s):
+    if allow_pattern_exemption and not cfg.get("strict_mode", False) and _contains_allowed_pattern(s):
         return False
 
     long_enough = len(s) >= cfg.get("min_length", 15)
@@ -295,19 +341,433 @@ def _is_secret_candidate(s: str, cfg: SecretCfg, custom_regex: list[str] | None 
     return _entropy(s) >= cfg.get("min_entropy", 3.7)
 
 
-def _detect_secret_keys(text: str, cfg: SecretCfg, custom_regex: list[str] | None = None) -> GuardrailResult:
+def _is_supported_embedded_candidate(value: str, cfg: SecretCfg) -> bool:
+    """Check a candidate from a supported exempt container.
+
+    Args:
+        value: Once-decoded query value or final file basename.
+        cfg: Secret-detection thresholds.
+
+    Returns:
+        True when the value has a supported provider-specific shape.
+    """
+    if _AWS_ACCESS_KEY_ID_RE.fullmatch(value):
+        return True
+    if not value.startswith(_EMBEDDED_KEY_PREFIXES):
+        return False
+    return _is_secret_candidate(
+        value,
+        cfg,
+        allow_pattern_exemption=False,
+    )
+
+
+def _find_url_shaped_scheme_start(
+    value: str,
+    boundaries: frozenset[str],
+    *,
+    preserve_embedded_prefix: bool,
+    prefer_explicit_within_generic: bool,
+) -> int | None:
+    """Find a boundary-aligned URL-shaped scheme in one pass.
+
+    Args:
+        value: Text to scan.
+        boundaries: Characters that may precede an independent scheme.
+        preserve_embedded_prefix: Whether a provider-prefixed value at offset
+            zero remains credential data rather than a URL shape.
+        prefer_explicit_within_generic: Whether a known explicit scheme inside
+            a broader generic scheme-shaped span takes precedence.
+
+    Returns:
+        The scheme offset, or ``None`` when no structural scheme exists.
+    """
+    explicit_start = next(
+        (
+            match.start()
+            for match in _EXPLICIT_URL_SCHEME_RE.finditer(value)
+            if (match.start() == 0 or value[match.start() - 1].isspace() or value[match.start() - 1] in boundaries)
+            and not (preserve_embedded_prefix and match.start() == 0 and value.startswith(_EMBEDDED_KEY_PREFIXES))
+        ),
+        None,
+    )
+    value_length = len(value)
+    position = 0
+    while position < value_length:
+        if value[position] not in _ASCII_SCHEME_START_CHARACTERS:
+            position += 1
+            continue
+
+        scheme_start = position
+        position += 1
+        while position < value_length and value[position] in _ASCII_SCHEME_CHARACTERS:
+            position += 1
+        if position >= value_length or value[position] != ":":
+            position += 1
+            continue
+
+        scheme = value[scheme_start:position].lower()
+        has_path_separator = position + 1 < value_length and value[position + 1] == "/"
+        matched_start: int | None = None
+        if len(scheme) >= 2 and has_path_separator:
+            matched_start = scheme_start
+        else:
+            for hostless_scheme in _HOSTLESS_URL_SCHEMES:
+                hostless_start = position - len(hostless_scheme)
+                if hostless_start < scheme_start or value[hostless_start:position].lower() != hostless_scheme:
+                    continue
+                hostless_preceding_character = value[hostless_start - 1] if hostless_start else ""
+                if hostless_start == 0 or hostless_preceding_character.isspace() or hostless_preceding_character in boundaries:
+                    matched_start = hostless_start
+                    break
+        if matched_start is not None:
+            matched_preceding_character = value[matched_start - 1] if matched_start else ""
+            starts_at_boundary = matched_start == 0 or matched_preceding_character.isspace() or matched_preceding_character in boundaries
+            if not starts_at_boundary:
+                matched_start = None
+        if matched_start is not None:
+            if explicit_start is not None and explicit_start < matched_start:
+                return explicit_start
+            if prefer_explicit_within_generic and explicit_start is not None and explicit_start < position:
+                return explicit_start
+            if not preserve_embedded_prefix or matched_start > 0 or not value.startswith(_EMBEDDED_KEY_PREFIXES):
+                return matched_start
+        position += 1
+        if has_path_separator:
+            while position < value_length and value[position] == "/":
+                position += 1
+    return explicit_start
+
+
+def _find_nested_url_start(value: str) -> int | None:
+    """Find the first structurally delimited nested URL.
+
+    Args:
+        value: Once-decoded query value.
+
+    Returns:
+        The nested scheme offset, or ``None`` when every scheme-like
+        occurrence is part of credential data.
+    """
+    nested_start = _find_url_shaped_scheme_start(
+        value,
+        _NESTED_URL_VALUE_BOUNDARIES,
+        preserve_embedded_prefix=True,
+        prefer_explicit_within_generic=False,
+    )
+    domain_spans = _detect_domain_like_url_spans(value)
+    ip_spans = _detect_ip_url_spans(value)
+    for detected_start, detected_end in merge(domain_spans, ip_spans):
+        if nested_start is not None and detected_start < nested_start < detected_end:
+            continue
+
+        preceding_character = value[detected_start - 1] if detected_start else ""
+        starts_at_boundary = detected_start == 0 or preceding_character.isspace() or preceding_character in _NESTED_URL_VALUE_BOUNDARIES
+        detected_url = value[detected_start:detected_end]
+        preserves_email_data = preceding_character == "@" and "/" not in detected_url and "\\" not in detected_url
+        preserves_owner_prefix = detected_start == 0 and value.startswith(_EMBEDDED_OWNER_PREFIXES)
+        if starts_at_boundary and not preserves_email_data and not preserves_owner_prefix:
+            if nested_start is None or detected_start < nested_start:
+                nested_start = detected_start
+    return nested_start
+
+
+def _find_structural_url_shape(text: str) -> int | None:
+    """Find the first token-level URL shape.
+
+    Args:
+        text: Raw whitespace-delimited token.
+
+    Returns:
+        The earliest independent scheme offset at the token start, after
+        presentation punctuation, or after an assignment delimiter. Returns
+        ``None`` when scheme-like text is ordinary basename data.
+    """
+    return _find_url_shaped_scheme_start(
+        text,
+        _STRUCTURAL_URL_SHAPE_BOUNDARIES,
+        preserve_embedded_prefix=False,
+        prefer_explicit_within_generic=True,
+    )
+
+
+def _has_supported_url_termination(text: str, start: int, url: str) -> bool:
+    """Return whether a detected URL ends at a supported source boundary.
+
+    Args:
+        text: Original whitespace-delimited token.
+        start: Inclusive source offset of the detected URL.
+        url: Cleaned URL returned by the shared detector.
+
+    Returns:
+        True when the URL reaches the token end or presentation punctuation.
+    """
+    end = start + len(url)
+    return end == len(text) or text[end].isspace() or text[end] in _ADJACENT_SCHEME_URL_BOUNDARIES
+
+
+def _get_detected_url_container_start(text: str, start: int, url: str) -> int | None:
+    """Return the independent container start for a detected URL.
+
+    Args:
+        text: Original whitespace-delimited token.
+        start: Inclusive source offset of the detected URL.
+        url: Cleaned URL returned by the shared detector.
+
+    Returns:
+        The container start, or ``None`` when the URL is embedded in ordinary
+        token text.
+    """
+    if start == 0:
+        return 0
+    if start == 2 and text.startswith("//") and _EXPLICIT_URL_SCHEME_RE.match(url) is None:
+        return 0
+
+    preceding_character = text[start - 1]
+    if preceding_character not in _STRUCTURAL_URL_SHAPE_BOUNDARIES:
+        return None
+    if preceding_character == ":" and _EXPLICIT_URL_SCHEME_RE.match(url) is None:
+        return None
+    return start
+
+
+def _iter_exempt_container_candidates(text: str) -> Iterator[str]:
+    """Yield candidates from explicitly supported exempt containers.
+
+    HTTP(S) URLs reuse the URL guardrail detector and expose query values only.
+    Non-URL file tokens expose only the final basename before an allowed
+    extension. URL paths, fragments, userinfo, nested URLs, intermediate path
+    segments, and malformed URL recovery are intentionally out of scope.
+
+    Args:
+        text: Raw whitespace-delimited token.
+
+    Yields:
+        Once-decoded query values or a final file basename.
+    """
+    container_text = text.strip("*")
+    first_scheme_start = _find_structural_url_shape(container_text)
+    detected_urls = _detect_urls(container_text, frozenset(("http", "https")))
+    located_urls: list[tuple[int, str]] = []
+    for detected_url in detected_urls:
+        search_start = 0
+        while (detected_start := container_text.find(detected_url, search_start)) >= 0:
+            located_urls.append((detected_start, detected_url))
+            search_start = detected_start + len(detected_url)
+    located_urls.sort(key=lambda located_url: (located_url[0], -len(located_url[1])))
+
+    first_detected_container: tuple[int, int, str] | None = None
+    for detected_start, detected_url in located_urls:
+        container_start = _get_detected_url_container_start(container_text, detected_start, detected_url)
+        if container_start is None:
+            continue
+        if first_detected_container is None or container_start < first_detected_container[0]:
+            first_detected_container = (container_start, detected_start, detected_url)
+
+    first_container_start = first_scheme_start
+    if first_detected_container is not None and (first_container_start is None or first_detected_container[0] <= first_container_start):
+        first_container_start = first_detected_container[0]
+
+    first_url_supports_file_prefix = first_container_start is None
+    if first_detected_container is not None and first_detected_container[0] == first_container_start:
+        _, detected_start, first_url = first_detected_container
+        first_url_supports_file_prefix = _has_supported_url_termination(
+            container_text,
+            detected_start,
+            first_url,
+        )
+        if first_url_supports_file_prefix and _HTTP_SCHEME_RE.match(first_url) is not None:
+            try:
+                parsed_first_url = urlparse(first_url)
+            except (ValueError, UnicodeError):
+                first_url_supports_file_prefix = False
+            else:
+                first_url_supports_file_prefix = _is_valid_http_url(parsed_first_url)
+    elif first_scheme_start is not None:
+        urls_at_first_scheme = [
+            detected_url
+            for detected_start, detected_url in located_urls
+            if detected_start == first_scheme_start and _EXPLICIT_URL_SCHEME_RE.match(detected_url) is not None
+        ]
+        if urls_at_first_scheme:
+            first_url = max(urls_at_first_scheme, key=len)
+            first_url_supports_file_prefix = _has_supported_url_termination(
+                container_text,
+                first_scheme_start,
+                first_url,
+            )
+            if first_url_supports_file_prefix and _HTTP_SCHEME_RE.match(first_url) is not None:
+                try:
+                    parsed_first_url = urlparse(first_url)
+                except (ValueError, UnicodeError):
+                    first_url_supports_file_prefix = False
+                else:
+                    first_url_supports_file_prefix = _is_valid_http_url(parsed_first_url)
+
+    for detected_start, detected_url in located_urls:
+        if _get_detected_url_container_start(container_text, detected_start, detected_url) is None:
+            continue
+        if _HTTP_SCHEME_RE.match(detected_url) is None:
+            continue
+        if not _has_supported_url_termination(container_text, detected_start, detected_url):
+            continue
+        try:
+            parsed_url = urlparse(detected_url)
+        except (ValueError, UnicodeError):
+            continue
+        if not _is_valid_http_url(parsed_url):
+            continue
+
+        for value in _iter_query_values(parsed_url.query):
+            nested_scheme_start = _find_nested_url_start(value)
+            if nested_scheme_start is not None:
+                value = value[:nested_scheme_start].rstrip("".join(_NESTED_URL_VALUE_BOUNDARIES)).rstrip()
+            if value:
+                yield value
+
+    file_text = container_text
+    if first_container_start is not None:
+        if not first_url_supports_file_prefix:
+            return
+        prefix = container_text[:first_container_start]
+        if not prefix or prefix[-1] not in _ADJACENT_SCHEME_URL_BOUNDARIES:
+            return
+        file_text = prefix.strip("".join(_ADJACENT_SCHEME_URL_BOUNDARIES))
+
+    file_text = file_text.strip("*#")
+    if _URL_SHAPED_SCHEME_RE.search(file_text) is not None:
+        return
+    lowered = file_text.lower()
+    for extension in ALLOWED_EXTENSIONS:
+        if not lowered.endswith(extension):
+            continue
+        raw_stem = file_text[: -len(extension)]
+        raw_basename = re.split(r"[\\/]", raw_stem)[-1]
+        basename = _decode_percent_encoded_component(
+            raw_basename,
+            plus_as_space=False,
+            literal_wrapper_characters="*#",
+        )
+        if basename:
+            yield basename
+        return
+
+
+def _is_valid_http_url(parsed_url: ParseResult) -> bool:
+    """Return whether a parsed HTTP(S) URL has a valid authority.
+
+    Args:
+        parsed_url: Parsed URL returned by ``urlparse``.
+
+    Returns:
+        True when the URL has a supported scheme, hostname, and port.
+    """
+    if parsed_url.scheme.lower() not in {"http", "https"}:
+        return False
+    try:
+        hostname = parsed_url.hostname
+        _port = parsed_url.port
+    except ValueError:
+        return False
+    return hostname is not None
+
+
+def _iter_query_values(query: str) -> Iterator[str]:
+    """Yield non-empty query values without materializing every field.
+
+    Args:
+        query: Raw URL query without the leading question mark.
+
+    Yields:
+        Once-decoded values from fields containing a non-empty value.
+    """
+    field_start = 0
+    while field_start <= len(query):
+        field_end = query.find("&", field_start)
+        if field_end < 0:
+            field_end = len(query)
+
+        value_separator = query.find("=", field_start, field_end)
+        if value_separator >= 0 and value_separator + 1 < field_end:
+            raw_value = query[value_separator + 1 : field_end]
+            value = _decode_percent_encoded_component(
+                raw_value,
+                plus_as_space=True,
+                literal_wrapper_characters="*",
+            )
+            if value is not None:
+                yield value
+
+        if field_end == len(query):
+            return
+        field_start = field_end + 1
+
+
+def _decode_percent_encoded_component(
+    value: str,
+    *,
+    plus_as_space: bool,
+    literal_wrapper_characters: str = "",
+) -> str | None:
+    """Decode one component only when all percent escapes form valid UTF-8.
+
+    Args:
+        value: Raw component text.
+        plus_as_space: Whether query-form plus signs represent spaces.
+        literal_wrapper_characters: Literal presentation characters to strip
+            from the component edges only after raw validation succeeds.
+
+    Returns:
+        The decoded component, or ``None`` when an escape or UTF-8 is invalid.
+    """
+    if re.search(r"%(?![0-9A-Fa-f]{2})", value) is not None:
+        return None
+
+    encoded_value = value.replace("+", " ") if plus_as_space else value
+    try:
+        decoded_value = unquote_to_bytes(encoded_value).decode("utf-8", errors="strict")
+    except (UnicodeDecodeError, UnicodeEncodeError):
+        return None
+
+    if not literal_wrapper_characters:
+        return decoded_value
+
+    normalized_value = value.strip(literal_wrapper_characters)
+    normalized_encoded_value = normalized_value.replace("+", " ") if plus_as_space else normalized_value
+    return unquote_to_bytes(normalized_encoded_value).decode("utf-8", errors="strict")
+
+
+def _detect_secret_keys(
+    text: str,
+    cfg: SecretCfg,
+    custom_regex: list[str] | None = None,
+) -> GuardrailResult:
     """Detect potential secret keys in text.
 
     Args:
-        text (str): Input text to scan.
-        cfg (SecretCfg): Secret detection criteria.
-        custom_regex (Optional[List[str]]): List of custom regex patterns to check.
+        text: Input text to scan.
+        cfg: Secret-detection thresholds.
+        custom_regex: Optional project-specific secret patterns.
 
     Returns:
-        GuardrailResult: Result containing flag status and detected secrets.
+        Guardrail result containing any detected secret tokens.
     """
-    words = (w.replace("*", "").replace("#", "") for w in re.findall(r"\S+", text))
-    secrets = [w for w in words if _is_secret_candidate(w, cfg, custom_regex)]
+    secrets: list[str] = []
+    for raw_word in re.findall(r"\S+", text):
+        structural_word = raw_word.replace("*", "")
+        word = structural_word.replace("#", "")
+        if _is_secret_candidate(word, cfg, custom_regex):
+            secrets.append(word)
+            continue
+
+        if not _contains_allowed_pattern(word):
+            continue
+        if len(raw_word) > _MAX_EXEMPT_CONTAINER_LENGTH:
+            secrets.append(word)
+            continue
+        candidates = _iter_exempt_container_candidates(raw_word)
+        if any(_is_supported_embedded_candidate(candidate, cfg) for candidate in candidates):
+            secrets.append(word)
 
     return GuardrailResult(
         tripwire_triggered=bool(secrets),

--- a/src/guardrails/checks/text/urls.py
+++ b/src/guardrails/checks/text/urls.py
@@ -26,6 +26,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from heapq import merge
 from ipaddress import AddressValueError, ip_address, ip_network
+from itertools import chain
 from typing import Any
 from urllib.parse import ParseResult, urlparse
 
@@ -42,13 +43,15 @@ DEFAULT_PORTS = {
     "https": 443,
 }
 
-SCHEME_PREFIX_RE = re.compile(r"^[a-z][a-z0-9+.-]*://")
+SCHEME_PREFIX_RE = re.compile(r"^[a-z][a-z0-9+.-]*://", re.IGNORECASE)
 _DOMAIN_HOST_CANDIDATE_PATTERN = r"[a-zA-Z0-9][a-zA-Z0-9.-]*"
 DOMAIN_HOST_CANDIDATE_RE = re.compile(rf"\b{_DOMAIN_HOST_CANDIDATE_PATTERN}", re.IGNORECASE)
 _AMBIGUOUS_DOMAIN_PATTERN = rf"(?<![A-Za-z0-9])(?i:{_DOMAIN_HOST_CANDIDATE_PATTERN})"
 AMBIGUOUS_DOMAIN_HOST_CANDIDATE_RE = re.compile(_AMBIGUOUS_DOMAIN_PATTERN)
-_IP_URL_PATTERN = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]+)?(?:/[^\s]*)?"
+_IP_HOST_PATTERN = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]+)?"
+_IP_URL_PATTERN = rf"{_IP_HOST_PATTERN}(?:/[^\s]*)?"
 IP_URL_RE = re.compile(rf"\b{_IP_URL_PATTERN}")
+_IP_HOST_RE = re.compile(rf"\b{_IP_HOST_PATTERN}")
 AMBIGUOUS_IP_URL_RE = re.compile(rf"(?<![A-Za-z0-9]){_IP_URL_PATTERN}")
 ASCII_LETTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 CASE_INSENSITIVE_ASCII_LETTERS = ASCII_LETTERS | frozenset("İıſK")
@@ -67,7 +70,43 @@ _POST_CONTROL_HARD_URL_BOUNDARIES = frozenset(('"', "`", "|", "^", "\\", "[", "{
 _POST_CONTROL_HARD_URL_BOUNDARY_RE = re.compile(r'["`|^\\\[{<]')
 _PAIRED_DELIMITER_OPEN_CODES = {"(": 1, "[": 2, "{": 3, "<": 4}
 _PAIRED_DELIMITER_CLOSE_TO_OPEN_CODE = {")": 1, "]": 2, "}": 3, ">": 4}
+_PRESENTATION_CLOSERS = {"(": ")", "[": "]", "{": "}", "<": ">", "'": "'", '"': '"', "`": "`"}
 _PAIRED_DELIMITER_RE = re.compile(r"[()\[\]{}<>]")
+_ADJACENT_SCHEME_URL_BOUNDARIES = (
+    _TRAILING_SENTENCE_PUNCTUATION
+    | frozenset(_PAIRED_DELIMITER_OPEN_CODES)
+    | frozenset(_PAIRED_DELIMITER_CLOSE_TO_OPEN_CODE)
+    | frozenset(("'", '"', "`"))
+)
+_ADJACENT_SCHEME_URL_BOUNDARY_CLASS = re.escape("".join(sorted(_ADJACENT_SCHEME_URL_BOUNDARIES)))
+_HIERARCHICAL_ADJACENT_SCHEME_URL_BOUNDARIES = _ADJACENT_SCHEME_URL_BOUNDARIES - frozenset(":")
+_HIERARCHICAL_ADJACENT_SCHEME_URL_BOUNDARY_CLASS = re.escape("".join(sorted(_HIERARCHICAL_ADJACENT_SCHEME_URL_BOUNDARIES)))
+_ADJACENT_DOMAIN_START_RE = re.compile(
+    rf"(?<=[{_ADJACENT_SCHEME_URL_BOUNDARY_CLASS}]){_DOMAIN_HOST_CANDIDATE_PATTERN}",
+    re.IGNORECASE,
+)
+_ADJACENT_IP_START_RE = re.compile(rf"(?<=[{_ADJACENT_SCHEME_URL_BOUNDARY_CLASS}])(?:[0-9]{{1,3}}\.){{3}}[0-9]{{1,3}}")
+_EXPLICIT_URL_SCHEME_PATTERN = r"(?:https?|ftp)://|(?:data|javascript|vbscript):"
+_EXPLICIT_URL_SCHEME_RE = re.compile(_EXPLICIT_URL_SCHEME_PATTERN, re.IGNORECASE)
+_HTTP_URL_CHARACTER_PATTERN = r'[^\s<>"{}|\\^`\[\]]'
+_BRACKETED_HTTP_AUTHORITY_PATTERN = r"https?://\[[^\]\s/?#]+\]"
+_HIERARCHICAL_URL_COMPONENT_PATTERN = (
+    r"(?:(?!["
+    + _HIERARCHICAL_ADJACENT_SCHEME_URL_BOUNDARY_CLASS
+    + r"](?:"
+    + _EXPLICIT_URL_SCHEME_PATTERN
+    + r"))(?:"
+    + _BRACKETED_HTTP_AUTHORITY_PATTERN
+    + "|"
+    + _HTTP_URL_CHARACTER_PATTERN
+    + r"))"
+)
+_HTTP_URL_COMPONENT_PATTERN = _HIERARCHICAL_URL_COMPONENT_PATTERN
+_HTTP_URL_PATTERN = r"https?://" + _HTTP_URL_COMPONENT_PATTERN + "+"
+_FTP_URL_PATTERN = r"ftp://" + _HIERARCHICAL_URL_COMPONENT_PATTERN + "+"
+_BRACKETED_HTTP_URL_PATTERN = _BRACKETED_HTTP_AUTHORITY_PATTERN + _HTTP_URL_COMPONENT_PATTERN + "*"
+_BRACKETED_HTTP_AUTHORITY_RE = re.compile(_BRACKETED_HTTP_AUTHORITY_PATTERN, re.IGNORECASE)
+_TRAILING_DETECTED_URL_PUNCTUATION_RE = re.compile(r"[.,;:!?)\]]+$")
 _DENSE_DELIMITER_SAMPLE_SIZE = 64
 _DENSE_DELIMITER_SAMPLE_WINDOW = 4_096
 _POST_CONTROL_UNMATCHED_URL_BOUNDARIES = frozenset(")]}>")
@@ -352,10 +391,30 @@ def _detect_domain_like_url_spans(
 
         match_end = match.start() + domain_end
         if domain_end == len(host_candidate) and match_end < len(text) and text[match_end] == "/":
-            match_end += 1
-            while match_end < len(text) and not text[match_end].isspace():
-                match_end += 1
+            match_end = _find_scheme_less_path_end(text, match_end)
 
+        detected_spans.append((match.start(), match_end))
+        search_position = match_end
+
+    return detected_spans
+
+
+def _detect_ip_url_spans(text: str) -> list[tuple[int, int]]:
+    """Detect IPv4 URL spans with adjacent-URL boundaries.
+
+    Args:
+        text: Text to scan for IPv4 URLs.
+
+    Returns:
+        Inclusive start and exclusive end offsets for IPv4 URLs.
+    """
+    detected_spans: list[tuple[int, int]] = []
+    search_position = 0
+
+    while match := _IP_HOST_RE.search(text, search_position):
+        match_end = match.end()
+        if match_end < len(text) and text[match_end] == "/":
+            match_end = _find_scheme_less_path_end(text, match_end)
         detected_spans.append((match.start(), match_end))
         search_position = match_end
 
@@ -1029,9 +1088,490 @@ def _find_ambiguous_url_candidates(
     return candidates
 
 
+def _is_nested_url_value_start(
+    text: str,
+    owner_end: int,
+    start: int,
+) -> bool:
+    """Return whether a scheme continues an owned URL query value.
+
+    Args:
+        text: Original text containing the scheme.
+        owner_end: Exclusive end of the previous owned URL span.
+        start: Inclusive scheme offset.
+
+    Returns:
+        True when the scheme remains inside the previous query-value span.
+    """
+    _ = text
+    return owner_end >= 0 and start < owner_end
+
+
+def _token_end(text: str, start: int) -> int:
+    """Return the end of the whitespace-delimited token at ``start``.
+
+    Args:
+        text: Source text containing the token.
+        start: Inclusive offset inside the token.
+
+    Returns:
+        The exclusive token end.
+    """
+    end = start
+    while end < len(text) and not text[end].isspace():
+        end += 1
+    return end
+
+
+def _presentation_wrapper_end(text: str, start: int, end: int) -> int | None:
+    """Return the end of an immediately enclosing presentation wrapper.
+
+    Args:
+        text: Source text containing the URL.
+        start: Inclusive URL offset.
+        end: Exclusive cleaned URL offset.
+
+    Returns:
+        The URL end when the next character closes an immediate wrapper, or
+        ``None`` when the URL is not immediately wrapped.
+    """
+    if start == 0 or end >= len(text):
+        return None
+    expected_closer = _PRESENTATION_CLOSERS.get(text[start - 1])
+    if expected_closer is None or text[end] != expected_closer:
+        return None
+    return end
+
+
+def _has_valid_http_authority(url: str) -> bool:
+    """Return whether text has a released-valid HTTP authority.
+
+    Args:
+        url: Candidate HTTP URL prefix.
+
+    Returns:
+        True when the prefix has an HTTP(S) scheme, nonempty host, and valid
+        port syntax.
+    """
+    try:
+        parsed_url = urlparse(url)
+        hostname = parsed_url.hostname
+        _port = parsed_url.port
+    except (ValueError, UnicodeError):
+        return False
+    return parsed_url.scheme.lower() in {"http", "https"} and hostname is not None
+
+
+def _has_open_http_query_value(url: str) -> bool:
+    """Return whether a valid HTTP URL ends with an empty query value.
+
+    Args:
+        url: Accepted explicit URL candidate.
+
+    Returns:
+        True when the URL has no fragment and its final query field ends in
+        an equals sign.
+    """
+    try:
+        parsed_url = urlparse(url)
+        hostname = parsed_url.hostname
+        _port = parsed_url.port
+    except (ValueError, UnicodeError):
+        return False
+
+    final_query_field = parsed_url.query.rsplit("&", 1)[-1]
+    value_separator = final_query_field.find("=")
+    return (
+        parsed_url.scheme.lower() in {"http", "https"}
+        and hostname is not None
+        and not parsed_url.fragment
+        and bool(parsed_url.query)
+        and value_separator == len(final_query_field) - 1
+    )
+
+
+def _clean_detected_scheme_url(url: str) -> str:
+    """Remove presentation punctuation from an explicit URL candidate.
+
+    Args:
+        url: Raw explicit-scheme candidate.
+
+    Returns:
+        Candidate without trailing presentation punctuation. A closing bracket
+        that terminates an IPv6 authority is preserved.
+    """
+    bracketed_authority = _BRACKETED_HTTP_AUTHORITY_RE.match(url)
+    structural_prefix_end = bracketed_authority.end() if bracketed_authority else 0
+    return url[:structural_prefix_end] + _TRAILING_DETECTED_URL_PUNCTUATION_RE.sub(
+        "",
+        url[structural_prefix_end:],
+    )
+
+
+def _iter_adjacent_url_starts(url: str, search_start: int) -> Iterator[int]:
+    """Yield boundary-aligned URL starts in source order.
+
+    Args:
+        url: Explicit URL candidate to scan.
+        search_start: Inclusive offset for nested candidates.
+
+    Yields:
+        Unique source offsets for explicit schemes, domains, and IPv4 hosts.
+    """
+    explicit_starts = (
+        match.start()
+        for match in _EXPLICIT_URL_SCHEME_RE.finditer(url, search_start)
+        if match.start() > search_start and url[match.start() - 1] in _ADJACENT_SCHEME_URL_BOUNDARIES
+    )
+    domain_starts = (match.start() for match in _ADJACENT_DOMAIN_START_RE.finditer(url, search_start) if _find_domain_end(match.group()) is not None)
+    ip_starts = (match.start() for match in _ADJACENT_IP_START_RE.finditer(url, search_start))
+    previous_start = -1
+    for start in merge(explicit_starts, domain_starts, ip_starts):
+        if start != previous_start:
+            yield start
+            previous_start = start
+
+
+def _is_adjacent_url_start(text: str, start: int) -> bool:
+    """Return whether presentation punctuation introduces a URL.
+
+    Args:
+        text: Source text containing the possible URL.
+        start: Inclusive offset immediately after presentation punctuation.
+
+    Returns:
+        True when an explicit, domain, or IPv4 URL starts at the offset.
+    """
+    if _EXPLICIT_URL_SCHEME_RE.match(text, start) is not None:
+        return True
+    domain_match = _ADJACENT_DOMAIN_START_RE.match(text, start)
+    if domain_match is not None and _find_domain_end(domain_match.group()) is not None:
+        return True
+    return _ADJACENT_IP_START_RE.match(text, start) is not None
+
+
+def _find_scheme_less_path_end(text: str, path_start: int) -> int:
+    """Find a scheme-less path end without rescanning later suffixes.
+
+    Args:
+        text: Source text containing the path.
+        path_start: Offset of the slash that begins the path.
+
+    Returns:
+        The exclusive path end at whitespace, token end, or an adjacent URL
+        presentation boundary.
+    """
+    position = path_start + 1
+    while position < len(text):
+        character = text[position]
+        if character.isspace():
+            return position
+        if character in _ADJACENT_SCHEME_URL_BOUNDARIES and position + 1 < len(text) and _is_adjacent_url_start(text, position + 1):
+            return position
+        position += 1
+    return position
+
+
+def _has_owned_http_query_value(url: str) -> bool:
+    """Return whether an empty query value owns a nested URL suffix.
+
+    Args:
+        url: Raw HTTP(S) candidate before presentation cleanup.
+
+    Returns:
+        True when a query field ending in ``=`` is followed only by nesting
+        punctuation before a URL-shaped descendant.
+    """
+    scheme_prefix_end = url.find("://") + 3
+    query_start = url.find("?", scheme_prefix_end)
+    if query_start < 0:
+        return False
+    fragment_start = url.find("#", query_start)
+    query_end = fragment_start if fragment_start >= 0 else len(url)
+    nested_boundaries = _ADJACENT_SCHEME_URL_BOUNDARIES | frozenset(("/", "\\"))
+
+    explicit_starts = (match.start() for match in _EXPLICIT_URL_SCHEME_RE.finditer(url, query_start + 1))
+    domain_starts = (
+        match.start() for match in _ADJACENT_DOMAIN_START_RE.finditer(url, query_start + 1) if _find_domain_end(match.group()) is not None
+    )
+    ip_starts = (match.start() for match in _ADJACENT_IP_START_RE.finditer(url, query_start + 1))
+    scan_position = query_start + 1
+    value_separator_found = False
+    separator_is_nested = True
+    separator_length = 0
+    separator_start = -1
+    field_owns_nested_urls = False
+    for start in chain(merge(explicit_starts, domain_starts, ip_starts), (query_end,)):
+        scan_end = min(start, query_end)
+        while scan_position < scan_end:
+            character = url[scan_position]
+            if character == "&":
+                value_separator_found = False
+                separator_is_nested = True
+                separator_length = 0
+                separator_start = -1
+                field_owns_nested_urls = False
+            elif not field_owns_nested_urls and not value_separator_found:
+                if character == "=":
+                    value_separator_found = True
+                    separator_is_nested = True
+                    separator_length = 0
+                    separator_start = scan_position + 1
+            elif not field_owns_nested_urls:
+                separator_length += 1
+                if character not in nested_boundaries:
+                    separator_is_nested = False
+            scan_position += 1
+        if start >= query_end:
+            break
+        if (
+            not field_owns_nested_urls
+            and value_separator_found
+            and separator_length
+            and separator_is_nested
+            and separator_start >= 0
+            and _mark_unmatched_closing_delimiters(url[separator_start:scan_end]) is None
+        ):
+            field_owns_nested_urls = True
+    return field_owns_nested_urls
+
+
+def _truncate_before_adjacent_scheme_less_url(url: str) -> str:
+    """Split a presentation-adjacent scheme-less URL from a scheme URL.
+
+    Args:
+        url: Raw explicit-scheme candidate.
+
+    Returns:
+        The explicit URL prefix, unless an active empty query value owns the
+        adjacent scheme-less candidate.
+    """
+    lowered_url = url.lower()
+    if not lowered_url.startswith(("http://", "https://")):
+        scheme_prefix_end = url.find(":") + 1
+        if scheme_prefix_end <= 0:
+            return url
+        data_payload_separator = url.find(",", scheme_prefix_end) if lowered_url.startswith("data:") else -1
+        for start in _iter_adjacent_url_starts(url, scheme_prefix_end):
+            boundary = start - 1
+            if boundary == data_payload_separator:
+                continue
+            return url[:boundary]
+        return url
+
+    scheme_prefix_end = url.find("://") + 3
+    component_starts = [position for delimiter in "/?#" if (position := url.find(delimiter, scheme_prefix_end)) >= 0]
+    first_component_start = min(component_starts, default=len(url))
+    userinfo_end = url.rfind("@", scheme_prefix_end, first_component_start)
+    query_start = url.find("?", first_component_start)
+    fragment_start = url.find("#", first_component_start)
+    authority_is_valid: bool | None = None
+    query_scan_position = query_start + 1
+    query_value_separator_found = False
+    query_value_has_content = False
+    query_field_owns_nested_urls = False
+    for start in _iter_adjacent_url_starts(url, scheme_prefix_end):
+        boundary = start - 1
+        boundary_character = url[boundary]
+        if start <= userinfo_end:
+            continue
+        if boundary_character == ":" and boundary < first_component_start:
+            return url
+        if boundary_character == "." and boundary < first_component_start:
+            continue
+        if authority_is_valid is None:
+            authority_is_valid = _has_valid_http_authority(url[:boundary])
+            if not authority_is_valid:
+                return url
+
+        in_query = query_start >= 0 and boundary > query_start and (fragment_start < 0 or boundary < fragment_start)
+        if in_query:
+            while query_scan_position < boundary:
+                character = url[query_scan_position]
+                if character == "&":
+                    query_value_separator_found = False
+                    query_value_has_content = False
+                    query_field_owns_nested_urls = False
+                elif not query_field_owns_nested_urls and not query_value_separator_found:
+                    if character == "=":
+                        query_value_separator_found = True
+                elif not query_field_owns_nested_urls:
+                    query_value_has_content = True
+                query_scan_position += 1
+            if query_field_owns_nested_urls:
+                continue
+            if query_value_separator_found and not query_value_has_content:
+                query_field_owns_nested_urls = True
+                continue
+        if boundary_character == "." and (fragment_start < 0 or boundary < fragment_start):
+            continue
+        return url[:boundary]
+
+    return url
+
+
+def _has_same_preserved_url_identity(source_url: str, preserved_url: str) -> bool:
+    """Compare URL identity while normalizing only scheme and host case.
+
+    Args:
+        source_url: URL spelling recovered from the source text.
+        preserved_url: Exact configured URL spelling.
+
+    Returns:
+        True when normalized authority and case-sensitive components match.
+    """
+    try:
+        source_parsed = urlparse(source_url)
+        preserved_parsed = urlparse(preserved_url)
+        same_authority = (
+            source_parsed.scheme.lower() == preserved_parsed.scheme.lower()
+            and source_parsed.hostname is not None
+            and preserved_parsed.hostname is not None
+            and source_parsed.hostname.lower() == preserved_parsed.hostname.lower()
+            and source_parsed.port == preserved_parsed.port
+        )
+    except (ValueError, UnicodeError):
+        return False
+    same_components = (
+        source_parsed.username == preserved_parsed.username
+        and source_parsed.password == preserved_parsed.password
+        and source_parsed.path == preserved_parsed.path
+        and source_parsed.params == preserved_parsed.params
+        and source_parsed.query == preserved_parsed.query
+        and source_parsed.fragment == preserved_parsed.fragment
+    )
+    return same_authority and same_components
+
+
+def _find_preserved_component_url_prefix(
+    raw_candidate: str,
+    preserved_component_urls: tuple[str, ...],
+) -> str | None:
+    """Find an exact allow-list URL at the start of a longer source span.
+
+    Args:
+        raw_candidate: Raw explicit-scheme regex candidate.
+        preserved_component_urls: Exact allow-list URL strings.
+
+    Returns:
+        The longest exact URL prefix ending before presentation punctuation or
+        an adjacent URL, or ``None`` when the candidate must use normal
+        adjacency splitting.
+    """
+    for preserved_url in preserved_component_urls:
+        source_prefix = raw_candidate[: len(preserved_url)]
+        if not _has_same_preserved_url_identity(source_prefix, preserved_url):
+            continue
+        if len(raw_candidate) == len(preserved_url):
+            return source_prefix
+
+        suffix = raw_candidate[len(preserved_url) :]
+        if (
+            source_prefix
+            and source_prefix[-1] in _ADJACENT_SCHEME_URL_BOUNDARIES
+            and _EXPLICIT_URL_SCHEME_RE.match(raw_candidate, len(preserved_url)) is not None
+        ):
+            return source_prefix
+        if suffix and all(character in _ADJACENT_SCHEME_URL_BOUNDARIES for character in suffix):
+            return source_prefix
+
+        for adjacent_start in _iter_adjacent_url_starts(raw_candidate, len(preserved_url)):
+            bridge = raw_candidate[len(preserved_url) : adjacent_start]
+            prefix_ends_with_boundary = source_prefix[-1] in _ADJACENT_SCHEME_URL_BOUNDARIES
+            if (bridge and all(character in _ADJACENT_SCHEME_URL_BOUNDARIES for character in bridge)) or (not bridge and prefix_ends_with_boundary):
+                return source_prefix
+            break
+    return None
+
+
+def _iter_preserved_component_url_spans(
+    text: str,
+    preserved_component_urls: tuple[str, ...],
+) -> Iterator[tuple[int, int, str, bool]]:
+    """Yield exact configured URL spans directly from source text.
+
+    Args:
+        text: Source text scanned for URLs.
+        preserved_component_urls: Exact allow-list URL strings.
+
+    Yields:
+        Scheme-candidate tuples preserving the original source spelling.
+    """
+    for scheme_match in _EXPLICIT_URL_SCHEME_RE.finditer(text):
+        start = scheme_match.start()
+        if start > 0 and not text[start - 1].isspace() and text[start - 1] not in _ADJACENT_SCHEME_URL_BOUNDARIES:
+            continue
+        for preserved_url in preserved_component_urls:
+            end = start + len(preserved_url)
+            if end > len(text):
+                continue
+            source_url = text[start:end]
+            if not _has_same_preserved_url_identity(source_url, preserved_url):
+                continue
+            if end < len(text):
+                next_character = text[end]
+                source_ends_with_boundary = source_url[-1] in _ADJACENT_SCHEME_URL_BOUNDARIES
+                adjacent_url = source_ends_with_boundary and _is_adjacent_url_start(text, end)
+                if not next_character.isspace() and next_character not in _ADJACENT_SCHEME_URL_BOUNDARIES and not adjacent_url:
+                    continue
+            yield start, end, source_url, False
+            break
+
+
+def _find_adjacent_explicit_url_after_prefix(raw_candidate: str, prefix_end: int) -> int | None:
+    """Find an explicit URL separated from a preserved source prefix.
+
+    Args:
+        raw_candidate: Raw explicit-scheme regex candidate.
+        prefix_end: Exclusive end of the preserved URL prefix.
+
+    Returns:
+        The adjacent URL start, or ``None`` when intervening text is content.
+    """
+    match = _EXPLICIT_URL_SCHEME_RE.search(raw_candidate, prefix_end)
+    if match is None:
+        return None
+    bridge = raw_candidate[prefix_end : match.start()]
+    prefix_ends_with_boundary = prefix_end > 0 and raw_candidate[prefix_end - 1] in _ADJACENT_SCHEME_URL_BOUNDARIES
+    if (bridge and all(character in _ADJACENT_SCHEME_URL_BOUNDARIES for character in bridge)) or (not bridge and prefix_ends_with_boundary):
+        return match.start()
+    return None
+
+
+def _released_url_detection_order(candidate: tuple[int, int, str]) -> tuple[int, int]:
+    """Return the released detector category and source order.
+
+    Args:
+        candidate: Source start, source end, and detected URL text.
+
+    Returns:
+        A stable ordering key that preserves the released pattern-category
+        order while retaining source order inside each category.
+    """
+    start, _, url = candidate
+    lowered_url = url.lower()
+    if lowered_url.startswith(("http://", "https://")):
+        category = 0
+    elif lowered_url.startswith("ftp://"):
+        category = 1
+    elif lowered_url.startswith("data:"):
+        category = 2
+    elif lowered_url.startswith("javascript:"):
+        category = 3
+    elif lowered_url.startswith("vbscript:"):
+        category = 4
+    elif IP_URL_RE.fullmatch(url) is not None:
+        category = 6
+    else:
+        category = 5
+    return category, start
+
+
 def _detect_urls(
     text: str,
     allowed_schemes: set[str] | frozenset[str] = frozenset(),
+    *,
+    preserved_component_urls: frozenset[str] = frozenset(),
 ) -> list[str]:
     """Detect URLs using regex patterns with deduplication.
 
@@ -1043,16 +1583,16 @@ def _detect_urls(
     Args:
         text: The text to scan for URLs.
         allowed_schemes: Additional configured scheme names to recognize.
+        preserved_component_urls: Exact URL strings whose valid components may
+            retain presentation punctuation followed by domain-shaped text.
 
     Returns:
         List of unique URL strings found in the text, with trailing
         punctuation removed.
     """
-    # Pattern for cleaning trailing punctuation (] must be escaped)
-    PUNCTUATION_CLEANUP = r"[.,;:!?)\]]+$"
-
     ambiguous_candidates = _find_ambiguous_url_candidates(text, allowed_schemes)
-    detected_urls = [candidate for candidate, _ in ambiguous_candidates]
+    preserved_component_url_prefixes = tuple(sorted(preserved_component_urls, key=len, reverse=True))
+    ambiguous_urls = [candidate for candidate, _ in ambiguous_candidates]
     if ambiguous_candidates:
         detection_characters = list(text)
         for _, (start, end) in ambiguous_candidates:
@@ -1063,78 +1603,184 @@ def _detect_urls(
 
     # Pattern 1: URLs with schemes (highest priority)
     scheme_patterns = [
-        r'https?://[^\s<>"{}|\\^`\[\]]+',
-        r'ftp://[^\s<>"{}|\\^`\[\]]+',
+        _BRACKETED_HTTP_URL_PATTERN,
+        # Let a presentation-delimited later explicit scheme start a new match.
+        _HTTP_URL_PATTERN,
+        _FTP_URL_PATTERN,
         r'data:[^\s<>"{}|\\^`\[\]]+',
         r'javascript:[^\s<>"{}|\\^`\[\]]+',
         r'vbscript:[^\s<>"{}|\\^`\[\]]+',
     ]
 
-    scheme_urls = set()
+    scheme_candidates = list(
+        _iter_preserved_component_url_spans(
+            text_without_ambiguous_candidates,
+            preserved_component_url_prefixes,
+        )
+    )
     for pattern in scheme_patterns:
-        matches = re.findall(pattern, text_without_ambiguous_candidates, re.IGNORECASE)
-        for match in matches:
+        matches = re.finditer(pattern, text_without_ambiguous_candidates, re.IGNORECASE)
+        for scheme_match in matches:
             # Clean trailing punctuation
-            cleaned = re.sub(PUNCTUATION_CLEANUP, "", match)
+            raw_candidate = scheme_match.group()
+            preserved_prefix = _find_preserved_component_url_prefix(
+                raw_candidate,
+                preserved_component_url_prefixes,
+            )
+            separated = preserved_prefix or _truncate_before_adjacent_scheme_less_url(raw_candidate)
+            cleaned = preserved_prefix or _clean_detected_scheme_url(separated)
+            candidate_start = scheme_match.start()
+            if (
+                preserved_prefix is None
+                and candidate_start > 0
+                and text_without_ambiguous_candidates[candidate_start - 1] == "'"
+                and cleaned.endswith("'")
+            ):
+                cleaned = cleaned[:-1]
             if cleaned:
-                detected_urls.append(cleaned)
-                # Track the domain part to avoid duplicates
-                if "://" in cleaned:
-                    domain_part = cleaned.split("://", 1)[1].split("/")[0].split("?")[0].split("#")[0]
-                    scheme_urls.add(domain_part.lower())
+                trailing_presentation = separated[len(cleaned) :]
+                source_suffix_start = candidate_start + len(cleaned)
+                source_suffix_starts_with_closer = (
+                    source_suffix_start < len(text_without_ambiguous_candidates)
+                    and text_without_ambiguous_candidates[source_suffix_start] in _PAIRED_DELIMITER_CLOSE_TO_OPEN_CODE
+                )
+                open_query_owns_suffix = (
+                    _has_open_http_query_value(cleaned)
+                    and not source_suffix_starts_with_closer
+                    and _mark_unmatched_closing_delimiters(trailing_presentation) is None
+                )
+                owns_query_value = preserved_prefix is None and (
+                    open_query_owns_suffix or (_has_valid_http_authority(cleaned) and _has_owned_http_query_value(raw_candidate))
+                )
+                scheme_candidates.append(
+                    (
+                        candidate_start,
+                        candidate_start + len(cleaned),
+                        cleaned,
+                        owns_query_value,
+                    )
+                )
+                if preserved_prefix is not None:
+                    adjacent_start = _find_adjacent_explicit_url_after_prefix(
+                        raw_candidate,
+                        len(preserved_prefix),
+                    )
+                    if adjacent_start is not None:
+                        adjacent_raw = raw_candidate[adjacent_start:]
+                        adjacent_url = _clean_detected_scheme_url(_truncate_before_adjacent_scheme_less_url(adjacent_raw))
+                        if adjacent_url:
+                            adjacent_source_start = candidate_start + adjacent_start
+                            scheme_candidates.append(
+                                (
+                                    adjacent_source_start,
+                                    adjacent_source_start + len(adjacent_url),
+                                    adjacent_url,
+                                    False,
+                                )
+                            )
+
+    covered_end = -1
+    nested_value_owner_end = -1
+    owned_query_spans: list[tuple[int, int]] = []
+    detected_candidates: list[tuple[int, int, str]] = []
+    current_token_end = -1
+    for start, end, cleaned, owns_query_value in sorted(
+        scheme_candidates,
+        key=lambda candidate: (candidate[0], -(candidate[1] - candidate[0])),
+    ):
+        if start < covered_end:
+            continue
+        if _is_nested_url_value_start(text, nested_value_owner_end, start):
+            covered_end = end
+            continue
+        detected_candidates.append((start, end, cleaned))
+        covered_end = end
+        if owns_query_value:
+            if end > current_token_end:
+                current_token_end = _token_end(text, end)
+            wrapper_end = _presentation_wrapper_end(text, start, end)
+            if wrapper_end is not None:
+                nested_value_owner_end = -1
+                continue
+            fragment_start = text.find("#", start, current_token_end)
+            field_end = text.find("&", end, current_token_end)
+            owner_boundaries = [boundary for boundary in (fragment_start, field_end) if boundary >= 0]
+            nested_value_owner_end = min(owner_boundaries, default=current_token_end)
+            if field_end >= 0 and (fragment_start < 0 or field_end < fragment_start):
+                extended_raw = text[start:current_token_end]
+                extended_url = _clean_detected_scheme_url(_truncate_before_adjacent_scheme_less_url(extended_raw))
+                extended_end = start + len(extended_url)
+                if extended_end > end:
+                    detected_candidates[-1] = (start, extended_end, extended_url)
+                    covered_end = extended_end
+            if end < nested_value_owner_end:
+                owned_query_spans.append((end, nested_value_owner_end))
+        else:
+            nested_value_owner_end = -1
+    fallback_characters = list(text_without_ambiguous_candidates)
+    for start, end, _, _ in scheme_candidates:
+        fallback_characters[start:end] = " " * (end - start)
+    for start, end in owned_query_spans:
+        fallback_characters[start:end] = " " * (end - start)
+    text_without_explicit_scheme_candidates = "".join(fallback_characters)
 
     # Pattern 2: Domain-like patterns (scheme-less) - but skip if already found with scheme
-    domain_matches = _detect_domain_like_urls(text_without_ambiguous_candidates)
+    domain_spans = _detect_domain_like_url_spans(text_without_explicit_scheme_candidates)
+    domain_candidates = ((start, end, text_without_explicit_scheme_candidates[start:end]) for start, end in domain_spans)
 
-    for match in domain_matches:
-        # Clean trailing punctuation
-        cleaned = re.sub(PUNCTUATION_CLEANUP, "", match)
+    # Pattern 3: IP addresses - merge with domains to preserve source order.
+    ip_spans = _detect_ip_url_spans(text_without_explicit_scheme_candidates)
+    ip_candidates = ((start, end, text_without_explicit_scheme_candidates[start:end]) for start, end in ip_spans)
+    for start, end, fallback_url in merge(
+        domain_candidates,
+        ip_candidates,
+        key=lambda candidate: candidate[0],
+    ):
+        _ = start, end
+        cleaned = _TRAILING_DETECTED_URL_PUNCTUATION_RE.sub("", fallback_url)
         if cleaned:
-            # Extract just the domain part for comparison
-            domain_part = cleaned.split("/")[0].split("?")[0].split("#")[0].lower()
-            # Only add if we haven't already found this domain with a scheme
-            if domain_part not in scheme_urls:
-                detected_urls.append(cleaned)
+            detected_candidates.append((start, start + len(cleaned), cleaned))
 
-    # Pattern 3: IP addresses - similar deduplication
-    ip_matches = IP_URL_RE.findall(text_without_ambiguous_candidates)
+    # Remove only non-adjacent bare hosts already represented by an explicit URL.
+    final_urls: list[str] = []
+    scheme_url_domains: set[str] = set()
+    ambiguous_explicit_urls = [url for url in ambiguous_urls if "://" in url]
+    ambiguous_scheme_less_urls = [url for url in ambiguous_urls if "://" not in url]
 
-    for match in ip_matches:
-        # Clean trailing punctuation
-        cleaned = re.sub(PUNCTUATION_CLEANUP, "", match)
-        if cleaned:
-            # Extract IP part for comparison
-            ip_part = cleaned.split("/")[0].split("?")[0].split("#")[0].lower()
-            if ip_part not in scheme_urls:
-                detected_urls.append(cleaned)
-
-    # Advanced deduplication: Remove domains that are already part of full URLs
-    final_urls = []
-    scheme_url_domains = set()
-
-    # First pass: collect all domains from scheme-ful URLs
-    for url in detected_urls:
-        if "://" in url:
-            try:
-                parsed = urlparse(url)
-                if parsed.hostname:
-                    scheme_url_domains.add(parsed.hostname.lower())
-                    # Also add www-stripped version
-                    bare_domain = parsed.hostname.lower().replace("www.", "")
-                    scheme_url_domains.add(bare_domain)
-            except (ValueError, UnicodeError):
-                # Skip URLs with parsing errors (malformed URLs, encoding issues)
-                # This is expected for edge cases and doesn't require logging
-                pass
+    # First pass: collect all domains from ordinary hierarchical URLs. Ambiguous
+    # candidates have already been removed from fallback detection by source span,
+    # so a surviving same-host fallback is a distinct occurrence.
+    ordinary_explicit_urls = (url for _, _, url in detected_candidates if "://" in url)
+    for url in ordinary_explicit_urls:
+        try:
+            parsed = urlparse(url)
+            if parsed.hostname:
+                scheme_url_domains.add(parsed.hostname.lower())
+                # Also add www-stripped version
+                bare_domain = parsed.hostname.lower().removeprefix("www.")
+                scheme_url_domains.add(bare_domain)
+        except (ValueError, UnicodeError):
+            # Skip URLs with parsing errors (malformed URLs, encoding issues)
+            # This is expected for edge cases and doesn't require logging
+            pass
+    # Second pass: retain source order while removing only legacy bare-host duplicates.
+    for start, _, url in sorted(detected_candidates, key=_released_url_detection_order):
+        if _EXPLICIT_URL_SCHEME_RE.match(url) is not None:
+            final_urls.append(url)
+            continue
+        url_lower = url.lower().removeprefix("www.")
+        presentation_adjacent = start > 0 and text[start - 1] in _ADJACENT_SCHEME_URL_BOUNDARIES
+        if presentation_adjacent or url_lower not in scheme_url_domains:
             final_urls.append(url)
 
-    # Second pass: only add scheme-less URLs if their domain isn't already covered
-    for url in detected_urls:
-        if "://" not in url:
-            # Check if this domain is already covered by a full URL
-            url_lower = url.lower().replace("www.", "")
-            if url_lower not in scheme_url_domains:
-                final_urls.append(url)
+    hierarchical_urls = [url for url in final_urls if "://" in url]
+    scheme_less_urls = [url for url in final_urls if "://" not in url]
+    final_urls = [
+        *ambiguous_explicit_urls,
+        *hierarchical_urls,
+        *ambiguous_scheme_less_urls,
+        *scheme_less_urls,
+    ]
 
     # Remove empty URLs and return unique list
     return list(dict.fromkeys([url for url in final_urls if url]))
@@ -1252,7 +1898,7 @@ def _is_url_allowed(
         return False
 
     url_host = url_host.lower()
-    url_domain = url_host.replace("www.", "")
+    url_domain = url_host.removeprefix("www.")
     scheme_lower = parsed_url.scheme.lower() if parsed_url.scheme else ""
     # Safely get port (rejects malformed ports)
     url_port = _safe_get_port(parsed_url, scheme_lower)
@@ -1271,7 +1917,7 @@ def _is_url_allowed(
         url_ip = None
 
     for allowed_entry in allow_list:
-        allowed_entry = allowed_entry.lower().strip()
+        allowed_entry = allowed_entry.strip()
 
         has_explicit_scheme = bool(SCHEME_PREFIX_RE.match(allowed_entry))
         if has_explicit_scheme:
@@ -1322,7 +1968,7 @@ def _is_url_allowed(
         if not allowed_host:
             continue
 
-        allowed_domain = allowed_host.replace("www.", "")
+        allowed_domain = allowed_host.removeprefix("www.")
 
         # Port matching: enforce if allow list has explicit port
         if allowed_port_explicit is not None and allowed_port != url_port:
@@ -1368,7 +2014,15 @@ async def urls(ctx: Any, data: str, config: URLConfig) -> GuardrailResult:
     _ = ctx
 
     # Detect URLs using regex patterns
-    detected_urls = _detect_urls(data, config.allowed_schemes)
+    normalized_allow_list_urls = (allowed_url.strip() for allowed_url in config.url_allow_list)
+    explicit_allow_list_urls = frozenset(
+        allowed_url for allowed_url in normalized_allow_list_urls if _EXPLICIT_URL_SCHEME_RE.match(allowed_url) is not None
+    )
+    detected_urls = _detect_urls(
+        data,
+        config.allowed_schemes,
+        preserved_component_urls=explicit_allow_list_urls,
+    )
 
     allowed, blocked = [], []
     blocked_reasons = []

--- a/tests/unit/checks/test_secret_keys.py
+++ b/tests/unit/checks/test_secret_keys.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import pytest
 
-from guardrails.checks.text.secret_keys import SecretKeysCfg, _detect_secret_keys, secret_keys
+from guardrails.checks.text.secret_keys import (
+    SecretKeysCfg,
+    _detect_secret_keys,
+    _find_nested_url_start,
+    secret_keys,
+)
 
 
 def test_detect_secret_keys_flags_high_entropy_strings() -> None:
@@ -29,7 +34,1233 @@ async def test_secret_keys_with_custom_regex() -> None:
 @pytest.mark.asyncio
 async def test_secret_keys_ignores_non_matching_input() -> None:
     """Benign inputs should not trigger the guardrail."""
-    config = SecretKeysCfg(threshold="permissive")
+    config = SecretKeysCfg(threshold="permissive", custom_regex=None)
     result = await secret_keys(None, "Hello world", config)
 
     assert result.tripwire_triggered is False  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://example.com/?token=sk-AAAABBBBCCCCDDDD",
+        "https://example.com/?token=sk%2DAAAABBBBCCCCDDDD",
+        "files/sk-AAAABBBBCCCCDDDD.png",
+        "files/sk%2DAAAABBBBCCCCDDDD.md",
+        "https://example.com/?key=AKIA1234567890ABCDEF",
+        "files/xoxb-AAAABBBBCCCC1.md",
+    ],
+)
+async def test_secret_keys_detects_supported_exempt_container_values(
+    text: str,
+) -> None:
+    """Provider credentials in query values and file basenames are detected."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("separator", [",", "("])
+async def test_adjacent_url_does_not_extend_a_short_query_candidate(separator: str) -> None:
+    """An adjacent URL cannot supply length or diversity to a query value."""
+    first_url = "https://example.com/?token=sk-ABCDEFGHIJ1"
+    adjacent_urls = f"{first_url}{separator}https://example.com/x"
+
+    first_result = await secret_keys(
+        None,
+        first_url,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+    adjacent_result = await secret_keys(
+        None,
+        adjacent_urls,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert first_result.tripwire_triggered is False  # noqa: S101
+    assert adjacent_result.tripwire_triggered is False  # noqa: S101
+    assert adjacent_result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_adjacent_url_does_not_suppress_a_file_candidate() -> None:
+    """A later URL cannot suppress a supported file-basename candidate."""
+    text = "files/sk-AAAABBBBCCCCDDDD.png,https://example.com"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_period_delimited_url_does_not_suppress_file_candidate() -> None:
+    """A broad scheme-like match cannot hide a later explicit URL."""
+    text = "files/sk-AAAABBBBCCCCDDDD.png.https://example.com"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "example.com/sk-AAAABBBBCCCCDDDD.png",
+        "www.example.com/sk-AAAABBBBCCCCDDDD.png",
+        "192.0.2.1/sk-AAAABBBBCCCCDDDD.png",
+        "//example.com/sk-AAAABBBBCCCCDDDD.png",
+    ],
+)
+async def test_scheme_less_url_path_is_not_a_file_candidate(text: str) -> None:
+    """Shared URL detection prevents scheme-less path reclassification."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", ["example.com/path", "192.0.2.1/path"])
+async def test_adjacent_scheme_less_url_does_not_suppress_file_candidate(url: str) -> None:
+    """A presentation-delimited scheme-less URL preserves the file prefix."""
+    text = f"files/sk-AAAABBBBCCCCDDDD.png,{url}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("destination", ["blocked.example/path", "192.0.2.1/path"])
+async def test_adjacent_url_does_not_pad_nonempty_query_value(destination: str) -> None:
+    """An adjacent destination cannot pad a short value ending in equals."""
+    text = f"https://outer.example/?token=sk-ABCDEFGHIJ=,{destination}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "https://example.com:bad",
+        "https://example.com:70000",
+        "https://example.com:blocked.example/path",
+        "https://example.com:192.0.2.1/path",
+        "https://[bad]",
+    ],
+)
+async def test_malformed_url_suffix_does_not_expose_file_candidate(suffix: str) -> None:
+    """Only a valid adjacent URL can delimit a preceding file candidate."""
+    text = f"files/sk-AAAABBBBCCCCDDDD.png,{suffix}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_malformed_url_prefix_cannot_alias_a_later_valid_url() -> None:
+    """A later valid URL cannot validate an earlier malformed prefix."""
+    text = "files/sk-AAAABBBBCCCCDDDD.png,https://example.com:bad,https://example.com"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hard_stop", ["\\", "|"])
+@pytest.mark.parametrize(
+    "text_template",
+    [
+        "https://example.com/?token=sk-AAAABBBBCCCCDDDD{hard_stop}tail",
+        "files/sk-AAAABBBBCCCCDDDD.png,https://example.com{hard_stop}tail",
+    ],
+)
+async def test_url_regex_hard_stop_does_not_expose_candidates(
+    hard_stop: str,
+    text_template: str,
+) -> None:
+    """A regex-truncated malformed URL cannot expose container contents."""
+    text = text_template.format(hard_stop=hard_stop)
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_secret_keys_detects_bracketed_ipv6_query_values() -> None:
+    """A valid bracketed IPv6 host exposes its query values."""
+    text = "https://[::1]/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_suffix", ["%", "%F", "%GG", "%FF"])
+async def test_query_value_decoding_rejects_malformed_encoding_atomically(
+    invalid_suffix: str,
+) -> None:
+    """Malformed escapes cannot pad an otherwise-short query candidate."""
+    text = f"https://example.com/?token=sk%2DABCDEFGHIJ1{invalid_suffix}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_query_value_decoding_accepts_valid_utf8_atomically() -> None:
+    """A completely valid encoded query credential remains detectable."""
+    text = "https://example.com/?token=sk%2DAAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_query_value_decoding_rejects_raw_invalid_unicode_atomically() -> None:
+    """Raw invalid Unicode cannot pad an otherwise-short query candidate."""
+    text = "https://example.com/?token=sk-ABCDEFGHIJ1\ud800"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "/https://example.com/x",
+        "%2Fhttps%3A%2F%2Fexample.com%2Fx",
+    ],
+)
+async def test_nested_url_does_not_extend_a_short_query_candidate(suffix: str) -> None:
+    """An unsupported nested URL cannot contribute to candidate scoring."""
+    text = f"https://example.com/?token=sk-ABCDEFGHIJ1{suffix}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://outer.example/?next=https://[::1]/?token=sk-AAAABBBBCCCCDDDD",
+        "https://outer.example/#https://[::1]/?token=sk-AAAABBBBCCCCDDDD",
+        "https://outer.example/?next=,https://inner.example/?token=sk-AAAABBBBCCCCDDDD",
+    ],
+)
+async def test_nested_url_query_values_remain_unsupported(text: str) -> None:
+    """Nested URL spans cannot expose their query credentials."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "ftp://allow.example/sk-AAAABBBBCCCCDDDD.png",
+        "data:text/plain/sk-AAAABBBBCCCCDDDD.png",
+        "javascript:/payload/sk-AAAABBBBCCCCDDDD.png",
+        "vbscript:/payload/sk-AAAABBBBCCCCDDDD.png",
+    ],
+)
+async def test_non_http_url_cannot_fall_through_to_file_candidate(text: str) -> None:
+    """A recognized URL scheme keeps its path out of file extraction."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "ftp://other.example/path",
+        "data:text/plain,x",
+        "javascript:alert(1)",
+        "vbscript:x",
+    ],
+)
+async def test_adjacent_non_http_url_cannot_suppress_query_secret(suffix: str) -> None:
+    """A later explicit URL cannot suppress a supported query candidate."""
+    text = f"https://example.com/?token=sk-AAAABBBBCCCCDDDD,{suffix}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value",
+    [
+        "sk-AAAABBBBdata:textCCCC1",
+        "sk-AAAABBBBftp://CCCC1",
+        "sk-AAAABBBBhttps://CCCC1",
+    ],
+)
+async def test_scheme_substring_inside_query_candidate_is_not_structural(value: str) -> None:
+    """Scheme text without a presentation boundary remains credential data."""
+    text = f"https://example.com/?token={value}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "mailto:/sk-AAAABBBBCCCCDDDD.png",
+        "custom://host/sk-AAAABBBBCCCCDDDD.png",
+        "custom:/path/sk-AAAABBBBCCCCDDDD.png",
+        "file:///tmp/sk-AAAABBBBCCCCDDDD.png",
+        "file:/tmp/sk-AAAABBBBCCCCDDDD.png",
+        "ssh://host/sk-AAAABBBBCCCCDDDD.png",
+    ],
+)
+async def test_generic_url_cannot_fall_through_to_file_candidate(text: str) -> None:
+    """An unsupported hierarchical URI is not a non-URL file token."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("separator", ["%23", "%26", "%3D", "%20", "%40"])
+async def test_once_decoded_nested_url_separator_is_structural(separator: str) -> None:
+    """A once-decoded URL separator isolates a nested URL suffix."""
+    text = f"https://example.com/?token=sk-ABCDEFGHIJ1{separator}https%3A%2F%2Fblocked.example%2Fx"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value",
+    [
+        "sk-Ahttps://B/https://inner.example/x",
+        "sk-Ahttps%3A%2F%2FB%2Fhttps%3A%2F%2Finner.example%2Fx",
+    ],
+)
+async def test_later_structural_nested_url_follows_scheme_text(value: str) -> None:
+    """Earlier credential text cannot hide a later nested URL boundary."""
+    text = f"https://outer.example/?token={value}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        ",mailto:user@example.com",
+        ",custom://host/path",
+        "%2Cmailto%3Auser%40example.com",
+        "%2Ccustom%3A%2F%2Fhost%2Fpath",
+    ],
+)
+async def test_generic_nested_url_suffix_cannot_pad_query_candidate(suffix: str) -> None:
+    """Generic nested URL shapes remain outside credential scoring."""
+    text = f"https://example.com/?token=sk-ABCDEFGHIJ1{suffix}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/sk-AAAAmailto:BBBBCCCC.png",
+        "files/sk-AAAAdata:textBBBBCCCC.png",
+    ],
+)
+async def test_scheme_text_inside_file_basename_is_not_structural(text: str) -> None:
+    """Embedded scheme text remains part of a supported file candidate."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("descendant", ["inner.example/path", "192.0.2.1/path"])
+async def test_scheme_less_nested_descendant_preserves_query_ownership(descendant: str) -> None:
+    """A nested scheme-less URL cannot expose a later nested credential."""
+    text = f"https://outer.example/?next=,{descendant},https://inner.example/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bridge", ['"inner.example/path,', ",(inner.example/path,"])
+async def test_nested_query_ownership_crosses_scheme_less_descendant(bridge: str) -> None:
+    """A nested scheme-less URL cannot expose a later nested credential."""
+    text = f"https://outer.example/?next={bridge}https://inner.example/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "first_url",
+    [
+        "https://outer.example/path=",
+        "https://outer.example/#label=",
+        "https://outer.example:bad/?next=",
+        "https://outer.example/?next==",
+    ],
+)
+async def test_non_query_text_cannot_own_an_adjacent_credential_url(first_url: str) -> None:
+    """Only a valid active query value can own an adjacent URL."""
+    text = f"{first_url},https://[::1]/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text.replace("#", "")]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "nested_urls",
+    [
+        "https://inner.example/,https://[::1]/?token=sk-AAAABBBBCCCCDDDD",
+        "(https://inner.example/),(https://[::1]/?token=sk-AAAABBBBCCCCDDDD)",
+    ],
+)
+async def test_nested_query_ownership_covers_adjacent_descendants(nested_urls: str) -> None:
+    """Nested descendants remain inside the unsupported query value."""
+    text = f"https://outer.example/?next=,{nested_urls}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://outer.example/https:?//inner&token=sk-AAAABBBBCCCCDDDD",
+        "https://outer.example/https%3A?%2F%2Finner&token=sk-AAAABBBBCCCCDDDD",
+        "https://outer.example/?token=sk-AAAABBBBCCCCDDDD&next=https:#//inner",
+    ],
+)
+async def test_component_boundaries_cannot_fabricate_a_nested_url(text: str) -> None:
+    """Unsupported URL components cannot suppress a supported query value."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text.replace("#", "")]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "nested_value",
+    [
+        "https://inner.example/",
+        "https%3A%2F%2Finner.example%2F",
+    ],
+)
+async def test_nested_query_value_cannot_suppress_a_sibling_secret(nested_value: str) -> None:
+    """A nested value cannot suppress a supported sibling query value."""
+    text = f"https://outer.example/?token=sk-AAAABBBBCCCCDDDD&next={nested_value}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "nested_value",
+    [
+        "https://inner.example/",
+        "inner.example/path",
+        "192.0.2.1/path",
+    ],
+)
+async def test_literal_nested_value_preserves_a_later_query_secret(
+    nested_value: str,
+) -> None:
+    """A literal nested value cannot consume a later outer query field."""
+    text = f"https://outer.example/?next=,{nested_value}&token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("opening", "closing"),
+    [("[", "]"), ("(", ")"), ("{", "}"), ("<", ">"), ("'", "'"), ('"', '"')],
+)
+async def test_wrapped_open_query_cannot_suppress_a_later_query_secret(
+    opening: str,
+    closing: str,
+) -> None:
+    """A presentation wrapper ends unsupported nested-value ownership."""
+    text = f"{opening}https://outer.example/?next={closing},https://[::1]/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_matched_single_quotes_do_not_pad_a_short_query_candidate() -> None:
+    """Matched single quotes remain presentation rather than query data."""
+    text = "'https://outer.example/?token=sk-ABCDEFGHIJ1'"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "encoded_descendant",
+    [
+        "inner.example%2Fpath",
+        "192.0.2.1%2Fpath",
+    ],
+)
+async def test_encoded_scheme_less_descendant_does_not_pad_a_short_candidate(
+    encoded_descendant: str,
+) -> None:
+    """Encoded scheme-less descendants match literal URL boundaries."""
+    text = f"https://outer.example/?token=sk-ABCDEFGHIJ1%2C{encoded_descendant}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host", ["inner.example", "192.0.2.1"])
+@pytest.mark.parametrize(
+    ("separator", "path_separator"),
+    [
+        ("/", "/"),
+        ("\\", "/"),
+        ("=", "/"),
+        ("@", "/"),
+        ("%2F", "%2F"),
+        ("%5C", "%2F"),
+        ("%3D", "%2F"),
+        ("%40", "%2F"),
+    ],
+)
+async def test_structural_descendant_does_not_pad_a_short_candidate(
+    host: str,
+    separator: str,
+    path_separator: str,
+) -> None:
+    """All approved structural boundaries isolate scheme-less descendants."""
+    text = f"https://outer.example/?token=sk-ABCDEFGHIJ1{separator}{host}{path_separator}path"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value",
+    [
+        "sk-AAAABBBB%40example.comCCCCDDDD",
+        "sk-example.com-AAAABBBBCCCCDDDD",
+    ],
+)
+async def test_domain_like_credential_data_remains_owned(value: str) -> None:
+    """Email-like and prefix-internal domains remain credential data."""
+    text = f"https://outer.example/?token={value}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "encoded_descendant",
+    [
+        "%09https%3A%2F%2Finner.example%2Fpath",
+        "%09inner.example%2Fpath",
+        "%09192.0.2.1%2Fpath",
+        "%2Fsk-inner.example%2Fpath",
+    ],
+)
+async def test_nested_url_cannot_hide_exact_aws_access_key(
+    encoded_descendant: str,
+) -> None:
+    """A decoded descendant cannot erase its credential owner."""
+    text = f"https://outer.example/?token=AKIA1234567890ABCDEF{encoded_descendant}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closer", [")", "]", "}", ">"])
+async def test_unmatched_closer_cannot_hide_sibling_query_secret(
+    closer: str,
+) -> None:
+    """An unmatched closer terminates open-query ownership."""
+    text = f"https://allow.example/?next={closer}https://blocked.example/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_nested_duplicate_cannot_hide_sibling_query_secret() -> None:
+    """A detected URL is evaluated at every non-overlapping occurrence."""
+    credential_url = "https://inner.example/?token=sk-AAAABBBBCCCCDDDD"
+    text = f"https://outer.example/?next={credential_url}&x=1,{credential_url}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+def test_nested_url_scan_is_linear_at_the_container_limit() -> None:
+    """Plain exact-limit query data is scanned once without URL retries."""
+    assert _find_nested_url_start("a" * (64 * 1024)) is None  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("-a.foo:/foo:/", 8),
+        ("=sk-.mailto:", 5),
+    ],
+)
+def test_nested_url_scan_preserves_non_overlapping_match_order(
+    value: str,
+    expected: int,
+) -> None:
+    """Linear scanning preserves legacy non-overlapping regex semantics."""
+    assert _find_nested_url_start(value) == expected  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://[bad]/sk-AAAABBBBCCCCDDDD.png",
+        "https://[bad]/sk-AAAABBBBCCCCDDDD.png,https://example.com",
+        "https://[bad]/sk-AAAABBBBCCCCDDDD.png(https://example.com",
+    ],
+)
+async def test_malformed_url_path_is_not_a_file_candidate(text: str) -> None:
+    """A malformed URL cannot fall through to file-basename handling."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "label=https://example.com/sk-AAAABBBBCCCCDDDD.png",
+        "label=https://[bad]/sk-AAAABBBBCCCCDDDD.png",
+    ],
+)
+async def test_assignment_prefixed_url_path_is_not_a_file_candidate(text: str) -> None:
+    """Assignment syntax cannot turn a URL path into a file candidate."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_assignment_prefixed_url_exposes_query_candidate() -> None:
+    """Assignment syntax preserves supported HTTP query extraction."""
+    text = "label=https://example.com/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authority",
+    [
+        "example.com:bad",
+        "example.com:70000",
+        "example.com:https://good.example",
+        "[::1]:https://good.example",
+    ],
+)
+async def test_malformed_url_authority_does_not_expose_query_values(authority: str) -> None:
+    """Malformed ports cannot opt query values into candidate scoring."""
+    text = f"https://{authority}/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_query_candidate_after_many_fields_is_detected() -> None:
+    """Query parsing remains streaming without imposing a field-count bypass."""
+    benign_fields = "&".join("field=value" for _ in range(1_000))
+    text = f"https://example.com/?{benign_fields}&token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_oversized_exempt_container_fails_closed() -> None:
+    """Oversized URL tokens cannot cause unbounded container parsing."""
+    text = f"https://example.com/?padding={'a' * (64 * 1024)}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_exact_limit_exempt_container_remains_bounded() -> None:
+    """The largest accepted exempt container is classified without rescans."""
+    prefix = "https://example.com/?padding="
+    text = prefix + "a" * (64 * 1024 - len(prefix))
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_oversized_marker_padded_container_fails_closed() -> None:
+    """Presentation markers cannot bypass the raw container-size bound."""
+    text = f"https://example.com/?padding={'*' * (64 * 1024)}"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text.replace("*", "")]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/#sk-AAAABBBBCCCCDDDD#.png",
+        "#files/sk-AAAABBBBCCCCDDDD.png#",
+        "files/*sk-AAAABBBBCCCCDDDD*.png",
+        "*files/sk-AAAABBBBCCCCDDDD.png*",
+        "files/sk-AAAABBBBCCCCDDDD.png*#",
+        "#*files/sk-AAAABBBBCCCCDDDD.png*#",
+    ],
+)
+async def test_file_presentation_markers_do_not_hide_candidates(text: str) -> None:
+    """Equivalent hash and star markers preserve file-candidate detection."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text.replace("*", "").replace("#", "")]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/s*k-AAAABBBBCCCCDDDD.png",
+        "files/s#k-AAAABBBBCCCCDDDD.png",
+    ],
+)
+async def test_internal_file_markers_remain_candidate_content(text: str) -> None:
+    """Literal markers inside a basename are content rather than wrappers."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("separator", ["%2F", "%2f", "%5C", "%5c"])
+async def test_encoded_file_separator_remains_in_raw_basename(separator: str) -> None:
+    """An encoded separator remains content in the raw final basename."""
+    text = f"files/sk-AAAABBBBCCCCDDDD{separator}tail.png"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected_secrets"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "invalid_encoding",
+    ["%", "%F", "%GG", "%FF", "%C0%AF", "%ED%A0%80"],
+)
+async def test_invalid_file_encoding_is_rejected_atomically(invalid_encoding: str) -> None:
+    """Invalid escapes and UTF-8 cannot synthesize candidate characters."""
+    text = f"files/sk-ABCDEFGHIJ1{invalid_encoding}.png"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/sk%*2DAAAABBBBCCCCDDDD.png",
+        "files/sk%#2DAAAABBBBCCCCDDDD.png",
+        "https://example.com/?token=sk%*2DAAAABBBBCCCCDDDD",
+    ],
+)
+async def test_presentation_markers_cannot_repair_percent_escapes(text: str) -> None:
+    """Marker removal cannot synthesize a valid percent escape."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/sk-ABCDEFGHIJ1%C3*%A9.png",
+        "files/sk-ABCDEFGHIJ1%C3#%A9.png",
+        "https://example.com/?token=sk-ABCDEFGHIJ1%C3*%A9",
+    ],
+)
+async def test_presentation_markers_cannot_repair_invalid_utf8(text: str) -> None:
+    """Marker removal occurs only after strict raw-component validation."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/%23sk-AAAABBBBCCCCDDDD%23.png",
+        "files/%2Ask-AAAABBBBCCCCDDDD%2A.png",
+        "https://example.com/?token=%2Ask-AAAABBBBCCCCDDDD%2A",
+    ],
+)
+async def test_encoded_markers_remain_candidate_content(text: str) -> None:
+    """Encoded marker characters are not presentation syntax."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_mid_token_url_does_not_expose_query_candidates() -> None:
+    """An HTTP substring without a container boundary remains unsupported."""
+    text = "files/prefixhttps://example.com/?token=sk-AAAABBBBCCCCDDDD.md"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_double_slash_prefixed_http_url_does_not_expose_query_candidates() -> None:
+    """A protocol-relative prefix cannot alias a later explicit scheme."""
+    text = "//https://example.com/?token=sk-AAAABBBBCCCCDDDD"
+
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "files/prefixhttps://example.com/sk-AAAABBBBCCCCDDDD.png",
+        "//https://example.com/sk-AAAABBBBCCCCDDDD.png",
+        "files/prefixssh://example.com/sk-AAAABBBBCCCCDDDD.png",
+    ],
+)
+async def test_rejected_url_shape_cannot_fall_through_to_file_candidate(text: str) -> None:
+    """A rejected URL-shaped span blocks standalone file extraction."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://example.com/sk-AAAABBBBCCCCDDDD",
+        "https://example.com/#token=sk-AAAABBBBCCCCDDDD",
+        "https://user:sk-AAAABBBBCCCCDDDD@example.com",
+        "https://example.com/sk-AAAABBBBCCCCDDDD.png",
+        "https://example.com/?token=token-AAAABBBBCCCCDDDD",
+        "https://example.com/?client_secret=Aa0Bb1Cc2Dd3Ee4Ff5",
+        "https://example.com/?token=sk%252DAAAABBBBCCCCDDDD",
+        "files/sk%252DAAAABBBBCCCCDDDD.png",
+        ("https://example.com/?next=https%3A%2F%2Finner.example%2F%3Ftoken%3Dsk-AAAABBBBCCCCDDDD"),
+        "files/sk-AAAABBBBCCCCDDDD/image.png",
+        "https://[bad]/?token=sk-AAAABBBBCCCCDDDD",
+    ],
+)
+async def test_secret_keys_keeps_unsupported_exempt_containers_exempt(
+    text: str,
+) -> None:
+    """The narrow container contract does not grow into URL interpretation."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_custom_regex_does_not_expand_exempt_container_contract() -> None:
+    """Custom patterns retain their existing whole-token matching semantics."""
+    result = await secret_keys(
+        None,
+        "files/internal-ab12.png",
+        SecretKeysCfg(
+            threshold="balanced",
+            custom_regex=[r"internal-[a-z0-9]{4}"],
+        ),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://example.com/?next=release-notes",
+        "files/archive.png",
+    ],
+)
+async def test_secret_keys_keeps_benign_supported_containers_exempt(
+    text: str,
+) -> None:
+    """Benign values remain exempt in the two supported containers."""
+    result = await secret_keys(
+        None,
+        text,
+        SecretKeysCfg(threshold="balanced", custom_regex=None),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected_secrets"] == []  # noqa: S101

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -27,6 +27,8 @@ from guardrails.checks.text.urls import (
     _find_ambiguous_url_candidates,
     _is_url_allowed,
     _mark_unmatched_closing_delimiters,
+    _token_end,
+    _truncate_before_adjacent_scheme_less_url,
     _validate_url_security,
     urls,
 )
@@ -115,6 +117,53 @@ def test_detect_urls_scales_linearly_for_invalid_domain_input() -> None:
     assert _detect_urls(small_text) == []  # noqa: S101
     assert _detect_urls(large_text) == []  # noqa: S101
     assert large_duration < small_duration * 3  # noqa: S101
+
+
+def test_adjacent_scanner_validates_malformed_authority_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Many suffix candidates cannot repeatedly parse one bad authority."""
+    parse_count = 0
+
+    def reject_authority(_url: str) -> bool:
+        nonlocal parse_count
+        parse_count += 1
+        return False
+
+    monkeypatch.setattr(
+        "guardrails.checks.text.urls._has_valid_http_authority",
+        reject_authority,
+    )
+    text = "https://[bad/" + ",a.example" * 2_000
+
+    assert _truncate_before_adjacent_scheme_less_url(text) == text  # noqa: S101
+    assert parse_count == 1  # noqa: S101
+
+
+def test_detect_urls_reuses_whitespace_token_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Owned candidates in one token share a single token-end scan."""
+    scan_count = 0
+
+    def count_token_end(text: str, start: int) -> int:
+        nonlocal scan_count
+        scan_count += 1
+        return _token_end(text, start)
+
+    monkeypatch.setattr("guardrails.checks.text.urls._token_end", count_token_end)
+    text = ",".join(f"https://h{index}.example/?next=,inner.example#frag" for index in range(500))
+
+    _detect_urls(text)
+
+    assert scan_count == 1  # noqa: S101
+
+
+def test_adjacent_query_scanner_scales_linearly() -> None:
+    """Adjacent query candidates do not rescan growing prefixes."""
+    small_text = "https://valid/?q=x" + ",a.example" * 1_000
+    large_text = "https://valid/?q=x" + ",a.example" * 4_000
+
+    small_duration = median(repeat(lambda: _detect_urls(small_text), number=1, repeat=7))
+    large_duration = median(repeat(lambda: _detect_urls(large_text), number=1, repeat=7))
+
+    assert large_duration < small_duration * 6  # noqa: S101
 
 
 def test_detect_urls_preserves_unicode_casefolded_domain() -> None:
@@ -310,6 +359,1250 @@ def test_detect_urls_deduplicates_scheme_and_domain() -> None:
     assert "http://example.com/path" in detected  # noqa: S101
     assert "example.com" not in detected  # noqa: S101
     assert "192.168.1.10:8080" in detected  # noqa: S101
+
+
+@pytest.mark.parametrize("separator", [",", "("])
+def test_detect_urls_splits_presentation_separated_scheme_urls(separator: str) -> None:
+    """A later scheme starts a new URL after presentation punctuation."""
+    first_url = "https://example.com/?token=sk-ABCDEFGHIJ1"
+    second_url = "https://example.com/x"
+
+    detected = _detect_urls(f"{first_url}{separator}{second_url}")
+
+    assert detected == [first_url, second_url]  # noqa: S101
+
+
+def test_detect_urls_recognizes_bracketed_ipv6_hosts() -> None:
+    """A valid bracketed IPv6 host remains one explicit URL."""
+    url = "https://[::1]/?token=sk-AAAABBBBCCCCDDDD"
+
+    assert _detect_urls(url) == [url]  # noqa: S101
+
+
+def test_detect_urls_stops_before_bracketed_presentation_text() -> None:
+    """Ordinary URLs retain the released bracket presentation boundary."""
+    url = "https://allow.example/path"
+
+    assert _detect_urls(f"{url}[annotation]") == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize("suffix", ["", ",", ")", "."])
+def test_detect_urls_preserves_bare_bracketed_ipv6_host(suffix: str) -> None:
+    """Presentation cleanup preserves the structural authority bracket."""
+    url = "https://[::1]"
+
+    assert _detect_urls(f"{url}{suffix}") == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "explicit_url",
+    [
+        "https://normal.example",
+        "https://normal.example:8443/path",
+        "https://normal.example/path?x=1",
+        "https://normal.example/path#fragment",
+        "https://[::1]",
+        "https://[::1]:8443/path",
+        "https://[::1]/path?x=1",
+        "https://[::1]/path#fragment",
+    ],
+)
+@pytest.mark.parametrize(
+    "scheme_less_url",
+    [
+        "blocked.example/path",
+        "192.0.2.1:8080/path",
+    ],
+)
+def test_detect_urls_splits_scheme_less_candidate_after_explicit_url(
+    explicit_url: str,
+    scheme_less_url: str,
+) -> None:
+    """An explicit URL cannot absorb an adjacent scheme-less candidate."""
+    assert _detect_urls(f"{explicit_url},{scheme_less_url}") == [  # noqa: S101
+        explicit_url,
+        scheme_less_url,
+    ]
+
+
+@pytest.mark.parametrize("separator", [",", "("])
+@pytest.mark.parametrize("destination", ["blocked.example/path", "192.0.2.1/path"])
+def test_nonempty_query_value_ending_in_equals_does_not_own_url(
+    separator: str,
+    destination: str,
+) -> None:
+    """A trailing equals inside value content does not imply emptiness."""
+    outer_url = "https://outer.example/?token=sk-ABCDEFGHIJ="
+
+    assert _detect_urls(f"{outer_url}{separator}{destination}") == [  # noqa: S101
+        outer_url,
+        destination,
+    ]
+
+
+def test_nested_query_ownership_resets_at_next_field() -> None:
+    """An owned empty value cannot authorize a later query field."""
+    outer_url = "https://outer.example/?next=,inner.example/path&token=x"
+    destination = "blocked.example/path"
+
+    assert _detect_urls(f"{outer_url},{destination}") == [  # noqa: S101
+        outer_url,
+        destination,
+    ]
+
+
+@pytest.mark.parametrize(
+    "nested_value",
+    [
+        "inner.example/path",
+        "inner.example/path,second.example/path",
+        "192.0.2.1/path,second.example/path",
+    ],
+)
+def test_detect_urls_keeps_scheme_less_url_in_owned_query_value(nested_value: str) -> None:
+    """An active empty query value retains nested scheme-less descendants."""
+    text = f"https://outer.example/?next=,{nested_value}"
+
+    assert _detect_urls(text) == [text]  # noqa: S101
+
+
+def test_detect_urls_keeps_domain_text_inside_data_url() -> None:
+    """HTTP adjacency rules cannot split a data URL payload."""
+    url = "data:text/plain,example.com"
+
+    assert _detect_urls(url) == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize("host", ["allow.example", "[::1]"])
+def test_detect_urls_splits_period_delimited_domain_after_fragment(host: str) -> None:
+    """A hostname suffix after fragment punctuation starts a new URL."""
+    explicit_url = f"https://{host}/path?x=1#frag"
+    scheme_less_url = "blocked.example/path"
+
+    assert _detect_urls(f"{explicit_url}.{scheme_less_url}") == [  # noqa: S101
+        explicit_url,
+        scheme_less_url,
+    ]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://allow.example/path/foo.blocked.example/archive",
+        "https://allow.example/?label=foo.blocked.example/path",
+        "https://[::1]/path/foo.blocked.example/archive",
+        "https://[::1]/?label=foo.blocked.example/path",
+    ],
+)
+def test_detect_urls_keeps_dotted_path_and_query_components(url: str) -> None:
+    """Domain-shaped path and query text stays inside its explicit URL."""
+    assert _detect_urls(url) == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/items/alpha,foo.com/detail",
+        "https://example.com/?labels=alpha,foo.com",
+        "https://example.com/#labels=alpha,foo.com",
+    ],
+)
+def test_detect_urls_preserves_domain_text_after_component_punctuation(url: str) -> None:
+    """Valid URL components retain punctuation followed by domain text."""
+    assert _detect_urls(  # noqa: S101
+        url,
+        preserved_component_urls=frozenset((url,)),
+    ) == [url]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/items/alpha,foo.com/detail",
+        "https://example.com/?labels=alpha,foo.com",
+        "https://example.com/#labels=alpha,foo.com",
+    ],
+)
+def test_exact_component_url_prefix_survives_wrappers_and_adjacency(url: str) -> None:
+    """Presentation text cannot expose punctuation inside an exact URL."""
+    preserved_urls = frozenset((url,))
+    blocked_url = "blocked.example/path"
+
+    assert _detect_urls(  # noqa: S101
+        f"({url})",
+        preserved_component_urls=preserved_urls,
+    ) == [url]
+    assert _detect_urls(  # noqa: S101
+        f"{url},{blocked_url}",
+        preserved_component_urls=preserved_urls,
+    ) == [url, blocked_url]
+
+
+@pytest.mark.parametrize(
+    "url, source",
+    [
+        ("https://allow.example/?", "https://allow.example/?,blocked.example/path"),
+        (
+            "https://allow.example/path/foo.com)",
+            "(https://allow.example/path/foo.com)),blocked.example/path",
+        ),
+    ],
+)
+def test_exact_component_url_skips_presentation_cleanup(url: str, source: str) -> None:
+    """Exact source punctuation remains part of the preserved URL."""
+    assert _detect_urls(  # noqa: S101
+        source,
+        preserved_component_urls=frozenset((url,)),
+    ) == [url, "blocked.example/path"]
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://allow.example/path?",
+        "https://allow.example/path)",
+        "https://allow.example/path]",
+    ],
+)
+@pytest.mark.parametrize(
+    "sibling",
+    [
+        "https://blocked.example/path",
+        "ftp://blocked.example/path",
+        "blocked.example/path",
+        "192.0.2.1/path",
+    ],
+)
+def test_exact_terminal_component_preserves_zero_bridge_sibling(
+    url: str,
+    sibling: str,
+) -> None:
+    """Exact terminal punctuation and an adjacent URL retain source spans."""
+    assert _detect_urls(  # noqa: S101
+        f"{url}{sibling}",
+        frozenset(("https", "ftp")),
+        preserved_component_urls=frozenset((url,)),
+    ) == [url, sibling]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/items/alpha,foo.com/detail",
+        "https://example.com/?labels=alpha,foo.com",
+    ],
+)
+async def test_urls_guardrail_exactly_allows_component_punctuation(url: str) -> None:
+    """Exact allow-list entries preserve path and query punctuation."""
+    result = await urls(
+        ctx=None,
+        data=url,
+        config=URLConfig(url_allow_list=[url], allowed_schemes={"https"}),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/items/alpha,foo.com/detail",
+        "https://example.com/?labels=alpha,foo.com",
+        "https://example.com/#labels=alpha,foo.com",
+    ],
+)
+async def test_exact_component_url_remains_allowed_before_adjacent_url(url: str) -> None:
+    """An exact URL stays allowed while a separate destination is blocked."""
+    blocked_url = "blocked.example/path"
+    result = await urls(
+        ctx=None,
+        data=f"({url}),{blocked_url}",
+        config=URLConfig(url_allow_list=[url], allowed_schemes={"https"}),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/items/alpha,foo.com/detail",
+        "https://example.com/?labels=alpha,foo.com",
+        "https://example.com/#labels=alpha,foo.com",
+    ],
+)
+async def test_normalized_exact_url_remains_allowed_before_adjacent_url(url: str) -> None:
+    """Allow-list normalization applies before component preservation."""
+    blocked_url = "blocked.example/path"
+    result = await urls(
+        ctx=None,
+        data=f"({url}),{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[f"  {url.replace('example.com', 'EXAMPLE.COM')}  "],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url, configured_url",
+    [
+        (
+            "https://example.com/items/ALPHA,foo.com/detail",
+            "https://example.com/items/alpha,foo.com/detail",
+        ),
+        (
+            "https://example.com/?labels=ALPHA,foo.com",
+            "https://example.com/?labels=alpha,foo.com",
+        ),
+        (
+            "https://example.com/#labels=ALPHA,foo.com",
+            "https://example.com/#labels=alpha,foo.com",
+        ),
+    ],
+)
+async def test_component_preservation_keeps_case_sensitive_source_identity(
+    url: str,
+    configured_url: str,
+) -> None:
+    """Preservation cannot rewrite case-sensitive URL components."""
+    blocked_url = "blocked.example/path"
+    result = await urls(
+        ctx=None,
+        data=f"({url}),{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[configured_url],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert url not in result.info["allowed"]  # noqa: S101
+    assert blocked_url in result.info["blocked"]  # noqa: S101
+    assert configured_url not in result.info["detected"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://example.com/items/ALPHA,foo.com/detail",
+        "https://example.com/?labels=ALPHA,foo.com",
+        "https://example.com/#labels=ALPHA,foo.com",
+    ],
+)
+async def test_exact_component_allow_list_preserves_matching_case(url: str) -> None:
+    """An exact allow-list entry retains case-sensitive components."""
+    result = await urls(
+        ctx=None,
+        data=url,
+        config=URLConfig(
+            url_allow_list=[url],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_exact_component_allow_list_normalizes_scheme_and_host_case() -> None:
+    """Scheme and host case do not change exact component identity."""
+    url = "https://example.com/?labels=ALPHA,foo.com"
+    result = await urls(
+        ctx=None,
+        data=url,
+        config=URLConfig(
+            url_allow_list=["HTTPS://EXAMPLE.COM/?labels=ALPHA,foo.com"],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source_userinfo, configured_userinfo",
+    [
+        ("alice", "bobby"),
+        ("alice:secret", "alice:other"),
+    ],
+)
+async def test_component_preservation_requires_exact_userinfo(
+    source_userinfo: str,
+    configured_userinfo: str,
+) -> None:
+    """Exact prefix preservation includes username and password identity."""
+    suffix = "example.com/items/alpha,foo.com/detail"
+    source_url = f"https://{source_userinfo}@{suffix}"
+    configured_url = f"https://{configured_userinfo}@{suffix}"
+    result = await urls(
+        ctx=None,
+        data=source_url,
+        config=URLConfig(
+            url_allow_list=[configured_url],
+            allowed_schemes={"https"},
+            block_userinfo=False,
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert configured_url not in result.info["detected"]  # noqa: S101
+    assert source_url not in result.info["allowed"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_preserved_open_query_cannot_hide_adjacent_url() -> None:
+    """A separated URL cannot become content of an exact empty query value."""
+    allowed_url = "https://allow.example/?next="
+    blocked_url = "blocked.example/path"
+    result = await urls(
+        ctx=None,
+        data=f"{allowed_url},{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[allowed_url],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [allowed_url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [allowed_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "blocked_url, allowed_schemes",
+    [
+        ("https://blocked.example/path", {"https"}),
+        ("ftp://blocked.example/path", {"https", "ftp"}),
+    ],
+)
+async def test_preserved_open_query_cannot_hide_adjacent_explicit_url(
+    blocked_url: str,
+    allowed_schemes: set[str],
+) -> None:
+    """A preserved empty value cannot own a separated explicit URL."""
+    allowed_url = "https://allow.example/?next="
+    result = await urls(
+        ctx=None,
+        data=f"{allowed_url},{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[allowed_url],
+            allowed_schemes=allowed_schemes,
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [allowed_url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [allowed_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "blocked_url, mismatched_allow_url",
+    [
+        ("http://blocked.example/path", "https://blocked.example/path"),
+        ("https://blocked.example/path", "http://blocked.example/path"),
+    ],
+)
+async def test_colon_adjacent_url_preserves_explicit_scheme(
+    blocked_url: str,
+    mismatched_allow_url: str,
+) -> None:
+    """A separated explicit URL retains scheme-qualified validation."""
+    allowed_url = "https://allow.example/?next="
+    result = await urls(
+        ctx=None,
+        data=f"{allowed_url}:{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[allowed_url, mismatched_allow_url],
+            allowed_schemes={"http", "https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [allowed_url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [allowed_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_colon_adjacent_url_preserves_userinfo_validation() -> None:
+    """A separated explicit URL retains userinfo validation."""
+    allowed_url = "https://allow.example/?next="
+    blocked_url = "https://user:pass@allowed.example/path"
+    result = await urls(
+        ctx=None,
+        data=f"{allowed_url}:{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[allowed_url, "allowed.example"],
+            allowed_schemes={"https"},
+            block_userinfo=True,
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [allowed_url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [allowed_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "allowed_url",
+    [
+        "https://allow.example/path:",
+        "https://allow.example/?label=value:",
+        "https://allow.example/#label:",
+    ],
+)
+async def test_terminal_boundary_preserves_adjacent_explicit_url(allowed_url: str) -> None:
+    """A boundary owned by an exact URL cannot erase its adjacent sibling."""
+    blocked_url = "https://user:pass@blocked.example/path"
+    result = await urls(
+        ctx=None,
+        data=f"{allowed_url}{blocked_url}",
+        config=URLConfig(
+            url_allow_list=[allowed_url, "blocked.example"],
+            allowed_schemes={"https"},
+            block_userinfo=True,
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [allowed_url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [allowed_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+def test_detect_urls_keeps_distinct_same_host_path() -> None:
+    """Host deduplication cannot discard a distinct adjacent path."""
+    explicit_url = "https://example.com/allowed"
+    scheme_less_url = "example.com/blocked"
+
+    assert _detect_urls(f"{explicit_url},{scheme_less_url}") == [  # noqa: S101
+        explicit_url,
+        scheme_less_url,
+    ]
+
+
+@pytest.mark.parametrize("scheme_less_url", ["example.com", "www.example.com"])
+def test_detect_urls_keeps_adjacent_bare_same_host(scheme_less_url: str) -> None:
+    """A source-distinct bare host remains a separate destination."""
+    explicit_url = "https://example.com/allowed"
+
+    assert _detect_urls(f"{explicit_url},{scheme_less_url}") == [  # noqa: S101
+        explicit_url,
+        scheme_less_url,
+    ]
+
+
+def test_detect_urls_preserves_released_candidate_category_order() -> None:
+    """HTTP candidates remain ahead of scheme-less candidates."""
+    first_url = "https://allowed.example/a"
+    second_url = "blocked.example/x"
+    third_url = "https://second.example/y"
+
+    assert _detect_urls(f"{first_url},{second_url} {third_url}") == [  # noqa: S101
+        first_url,
+        third_url,
+        second_url,
+    ]
+
+
+def test_detect_urls_splits_adjacent_ipv4_after_explicit_ipv4() -> None:
+    """An explicit IPv4 path cannot absorb an adjacent IPv4 URL."""
+    explicit_url = "https://192.0.2.1/allowed"
+    scheme_less_url = "203.0.113.2/blocked"
+
+    assert _detect_urls(f"{explicit_url},{scheme_less_url}") == [  # noqa: S101
+        explicit_url,
+        scheme_less_url,
+    ]
+
+
+@pytest.mark.parametrize("separator", [",", "("])
+@pytest.mark.parametrize(
+    ("first_url", "second_url", "expected"),
+    [
+        (
+            "first.example/path",
+            "second.example/path",
+            ["first.example/path", "second.example/path"],
+        ),
+        (
+            "first.example/path",
+            "203.0.113.2/path",
+            ["first.example/path", "203.0.113.2/path"],
+        ),
+        (
+            "192.0.2.1/path",
+            "second.example/path",
+            ["second.example/path", "192.0.2.1/path"],
+        ),
+        (
+            "192.0.2.1/path",
+            "203.0.113.2/path",
+            ["192.0.2.1/path", "203.0.113.2/path"],
+        ),
+    ],
+)
+def test_detect_urls_splits_adjacent_scheme_less_paths(
+    separator: str,
+    first_url: str,
+    second_url: str,
+    expected: list[str],
+) -> None:
+    """Presentation boundaries split every scheme-less producer pair."""
+    assert _detect_urls(f"{first_url}{separator}{second_url}") == expected  # noqa: S101
+
+
+def test_detect_urls_preserves_released_fallback_category_order() -> None:
+    """Domain candidates remain ahead of IPv4 candidates."""
+    explicit_url = "https://outer.example"
+    ipv4_url = "192.0.2.1"
+    domain_url = "blocked.example"
+
+    assert _detect_urls(f"{explicit_url},{ipv4_url},{domain_url}") == [  # noqa: S101
+        explicit_url,
+        domain_url,
+        ipv4_url,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "blocked.example https://later.example",
+            ["https://later.example", "blocked.example"],
+        ),
+        (
+            "192.0.2.1 https://later.example",
+            ["https://later.example", "192.0.2.1"],
+        ),
+        (
+            "ftp://ftp.example https://later.example",
+            ["https://later.example", "ftp://ftp.example"],
+        ),
+        (
+            "data:text/plain,x https://later.example ftp://ftp.example javascript:alert",
+            [
+                "https://later.example",
+                "ftp://ftp.example",
+                "data:text/plain,x",
+                "javascript:alert",
+            ],
+        ),
+    ],
+)
+def test_detect_urls_preserves_released_mixed_category_order(
+    text: str,
+    expected: list[str],
+) -> None:
+    """Unrelated inputs retain the released detector ordering."""
+    assert _detect_urls(text) == expected  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "trusted.co\tm data:text/plain,x",
+            ["trusted.co\tm", "data:text/plain,x"],
+        ),
+        (
+            "trusted.co\tm normal.example https://later.example",
+            ["https://later.example", "trusted.co\tm", "normal.example"],
+        ),
+        (
+            "trusted.co\tm ftp://later.example javascript:alert blocked.example 192.0.2.1",
+            [
+                "ftp://later.example",
+                "trusted.co\tm",
+                "javascript:alert",
+                "blocked.example",
+                "192.0.2.1",
+            ],
+        ),
+    ],
+)
+def test_detect_urls_preserves_released_ambiguous_candidate_order(
+    text: str,
+    expected: list[str],
+) -> None:
+    """Ambiguous scheme-less candidates lead the fallback pass."""
+    assert _detect_urls(text) == expected  # noqa: S101
+
+
+def test_ambiguous_explicit_url_keeps_source_distinct_same_host_fallback() -> None:
+    """Ambiguous hierarchical URLs do not hide separate same-host input."""
+    ambiguous_url = "https://allowed.example/pa\tth"
+
+    assert _detect_urls(f"{ambiguous_url} allowed.example") == [  # noqa: S101
+        ambiguous_url,
+        "allowed.example",
+    ]
+
+
+def test_host_deduplication_removes_only_a_leading_www_label() -> None:
+    """Embedded www labels cannot hide a source-distinct bare host."""
+    explicit_url = "https://notwww.example.com/path"
+    bare_host = "notexample.com"
+
+    assert _detect_urls(f"{explicit_url} {bare_host}") == [  # noqa: S101
+        explicit_url,
+        bare_host,
+    ]
+
+
+def test_scheme_less_path_scanner_scales_linearly() -> None:
+    """Adjacent scheme-less paths do not rescan the remaining suffix."""
+    small_text = ",".join(f"d{index}.example/path" for index in range(1_000))
+    large_text = ",".join(f"d{index}.example/path" for index in range(4_000))
+
+    small_duration = median(repeat(lambda: _detect_urls(small_text), number=1, repeat=5))
+    large_duration = median(repeat(lambda: _detect_urls(large_text), number=1, repeat=5))
+
+    assert large_duration < small_duration * 6  # noqa: S101
+
+
+@pytest.mark.parametrize("bridge", ['"inner.example/path,', ",(inner.example/path,"])
+def test_detect_urls_keeps_nested_scheme_after_scheme_less_descendant(bridge: str) -> None:
+    """An open query value owns chained URLs throughout its source token."""
+    text = f"https://outer.example/?next={bridge}https://inner.example/path"
+
+    assert _detect_urls(text) == ["https://outer.example/?next="]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    ("opening", "closing"),
+    [("[", "]"), ("(", ")"), ("{", "}"), ("<", ">"), ("'", "'"), ('"', '"')],
+)
+@pytest.mark.parametrize(
+    "sibling_url",
+    [
+        "https://[::1]/path",
+        "blocked.example/path",
+        "192.0.2.1/path",
+    ],
+)
+def test_wrapped_open_query_does_not_own_a_sibling_url(
+    opening: str,
+    closing: str,
+    sibling_url: str,
+) -> None:
+    """A matching presentation closer ends nested query ownership."""
+    outer_url = "https://outer.example/?next="
+    text = f"{opening}{outer_url}{closing},{sibling_url}"
+
+    assert _detect_urls(text) == [outer_url, sibling_url]  # noqa: S101
+
+
+def test_matched_single_quotes_do_not_extend_a_detected_url() -> None:
+    """A matched single quote remains outside the detected URL span."""
+    url = "https://outer.example/?token=sk-ABCDEFGHIJ1"
+
+    assert _detect_urls(f"'{url}'") == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "nested_value",
+    [
+        "https://inner.example/",
+        "inner.example/path",
+        "192.0.2.1/path",
+    ],
+)
+def test_nested_query_ownership_resumes_at_the_next_field(nested_value: str) -> None:
+    """A raw field separator resumes the accepted outer URL."""
+    text = f"https://outer.example/?next=,{nested_value}&token=value"
+
+    assert _detect_urls(text) == [text]  # noqa: S101
+
+
+@pytest.mark.parametrize("host", ["outer.example", "[::1]"])
+def test_nested_query_ownership_ends_before_fragment_destination(host: str) -> None:
+    """Query ownership cannot suppress a later fragment-adjacent URL."""
+    outer_url = f"https://{host}/?next=,inner.example/path#frag"
+    blocked_url = "blocked.example/path"
+
+    assert _detect_urls(f"{outer_url}.{blocked_url}") == [  # noqa: S101
+        outer_url,
+        blocked_url,
+    ]
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "ftp://blocked.example/path",
+        "data:text/plain,x",
+        "javascript:alert",
+        "vbscript:x",
+    ],
+)
+def test_detect_urls_splits_adjacent_non_http_scheme(suffix: str) -> None:
+    """A presentation-adjacent explicit scheme starts a new URL span."""
+    outer_url = "https://allow.example/#frag"
+
+    assert _detect_urls(f"{outer_url},{suffix}") == [outer_url, suffix]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        "example.com:blocked.example/path",
+        "example.com:192.0.2.1/path",
+        "example.com:https://good.example/path",
+        "[::1]:https://good.example/path",
+    ],
+)
+def test_detect_urls_preserves_malformed_port_candidate(authority: str) -> None:
+    """Invalid authority ports remain intact for fail-closed validation."""
+    url = f"https://{authority}"
+
+    assert _detect_urls(url) == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize("prefix", ["data:text/plain,payload", "javascript:alert", "vbscript:x"])
+@pytest.mark.parametrize("suffix", ["blocked.example/path", "192.0.2.1/path"])
+def test_detect_urls_splits_destination_after_hostless_payload(prefix: str, suffix: str) -> None:
+    """A hostless payload cannot mask a later destination."""
+    assert _detect_urls(f"{prefix},{suffix}") == [prefix, suffix]  # noqa: S101
+
+
+@pytest.mark.parametrize("host", ["localhost", "intranet", "devbox"])
+def test_detect_urls_splits_destination_after_single_label_host(host: str) -> None:
+    """Every released-valid HTTP host supports adjacency splitting."""
+    explicit_url = f"https://{host}/ok"
+    blocked_url = "blocked.example/path"
+
+    assert _detect_urls(f"{explicit_url},{blocked_url}") == [  # noqa: S101
+        explicit_url,
+        blocked_url,
+    ]
+
+
+@pytest.mark.parametrize("descendant", ["inner.example/path", "192.0.2.1/path"])
+def test_query_owner_covers_scheme_less_then_explicit_descendant(descendant: str) -> None:
+    """A scheme-less descendant cannot end empty-query ownership."""
+    text = f"https://outer.example/?next=,{descendant},https://inner.example/?token=value"
+
+    assert _detect_urls(text) == [f"https://outer.example/?next=,{descendant}"]  # noqa: S101
+
+
+def test_detect_urls_preserves_source_order_for_bracketed_hosts() -> None:
+    """Bracketed-host matches remain ordered by their source offsets."""
+    first_url = "https://normal.example/a"
+    second_url = "https://[::1]/b"
+
+    assert _detect_urls(f"{first_url} {second_url}") == [first_url, second_url]  # noqa: S101
+
+
+@pytest.mark.parametrize("prefix", ["label=(", "label=,"])
+def test_detect_urls_preserves_top_level_urls_after_assignment_text(prefix: str) -> None:
+    """Assignment-like prose cannot claim ownership of a following URL."""
+    url = "https://[::1]/path"
+
+    assert _detect_urls(f"{prefix}{url}") == [url]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "first_url",
+    [
+        "https://outer.example/path=",
+        "https://outer.example/#label=",
+        "https://outer.example:bad/?next=",
+        "https://outer.example/?next==",
+    ],
+)
+def test_detect_urls_requires_valid_query_ownership(first_url: str) -> None:
+    """Unsupported components and malformed URLs cannot own a sibling URL."""
+    second_url = "https://[::1]/?token=value"
+
+    assert _detect_urls(f"{first_url},{second_url}") == [first_url, second_url]  # noqa: S101
+
+
+@pytest.mark.parametrize(
+    "authority",
+    [
+        "outer.example:bad",
+        "outer.example:70000",
+        "outer.example:https://good.example",
+        "[bad]",
+    ],
+)
+@pytest.mark.parametrize("bridge", ["inner.example/path", "192.0.2.1/path"])
+def test_malformed_query_owner_cannot_bridge_to_sibling_url(
+    authority: str,
+    bridge: str,
+) -> None:
+    """A malformed authority cannot suppress a later valid URL."""
+    malformed_url = f"https://{authority}/?next="
+    valid_url = "https://inner.example/?token=sk-AAAABBBBCCCCDDDD"
+    text = f"{malformed_url},{bridge},{valid_url}"
+
+    assert _detect_urls(text) == [f"{malformed_url},{bridge}", valid_url]  # noqa: S101
+
+
+@pytest.mark.parametrize("closer", [")", "]", "}", ">"])
+@pytest.mark.parametrize(
+    "sibling_url",
+    [
+        "blocked.example/path",
+        "192.0.2.1/path",
+        "https://blocked.example/path",
+    ],
+)
+def test_unmatched_closer_terminates_open_query_ownership(
+    closer: str,
+    sibling_url: str,
+) -> None:
+    """An unmatched closer leaves the following URL independently visible."""
+    outer_url = "https://allow.example/?next="
+
+    assert _detect_urls(f"{outer_url}{closer},{sibling_url}") == [  # noqa: S101
+        outer_url,
+        sibling_url,
+    ]
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        (
+            "https://outer.example/?next=https://[::1]/?token=value",
+            ["https://outer.example/?next=https://[::1]/?token=value"],
+        ),
+        (
+            "https://outer.example/x/https://[fe80::1%25eth0]:8443/?token=value",
+            ["https://outer.example/x/https://[fe80::1%25eth0]:8443/?token=value"],
+        ),
+        (
+            "https://outer.example/?next=,https://inner.example/?token=value",
+            ["https://outer.example/?next="],
+        ),
+        (
+            "https://outer.example/?next=,https://inner.example/,https://[::1]/?token=value",
+            ["https://outer.example/?next="],
+        ),
+        (
+            "https://outer.example/?next=(https://inner.example/),(https://[::1]/?token=value)",
+            ["https://outer.example/?next="],
+        ),
+        (
+            "https://outer.example/?next=,https://127.0.0.1/?token=value",
+            ["https://outer.example/?next="],
+        ),
+        (
+            "https://outer.example/?next=,https://192.168.1.10:8080/?token=value",
+            ["https://outer.example/?next="],
+        ),
+    ],
+)
+def test_detect_urls_does_not_promote_nested_urls(
+    text: str,
+    expected: list[str],
+) -> None:
+    """Nested schemes do not become independent top-level URL spans."""
+    assert _detect_urls(text) == expected  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_ignores_bracketed_presentation_suffix() -> None:
+    """Presentation text cannot invalidate an exact-path allow-list entry."""
+    url = "https://allow.example/path"
+    config = URLConfig(
+        url_allow_list=[url],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=f"{url}[annotation]", config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_allows_allowlisted_bracketed_ipv6_host() -> None:
+    """Normal bracketed IPv6 URLs reach the shared validation path."""
+    url = "https://[::1]/docs"
+    config = URLConfig(
+        url_allow_list=["[::1]"],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=url, config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_allows_bare_allowlisted_bracketed_ipv6_host() -> None:
+    """A bare bracketed IPv6 authority reaches allow-list validation intact."""
+    url = "https://[::1]"
+    config = URLConfig(
+        url_allow_list=["[::1]"],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=f"{url},", config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == [url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_does_not_promote_nested_ipv4_fallback() -> None:
+    """Scheme-less fallback cannot reintroduce an owned nested IPv4 URL."""
+    outer_url = "https://outer.example/?next="
+    text = f"{outer_url},https://127.0.0.1/?token=value"
+    config = URLConfig(
+        url_allow_list=["outer.example"],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.tripwire_triggered is False  # noqa: S101
+    assert result.info["detected"] == [outer_url]  # noqa: S101
+    assert result.info["allowed"] == [outer_url]  # noqa: S101
+    assert result.info["blocked"] == []  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "explicit_url, allow_entry",
+    [
+        ("https://normal.example", "normal.example"),
+        ("https://normal.example:8443/path", "normal.example"),
+        ("https://normal.example/path?x=1", "normal.example"),
+        ("https://normal.example/path#fragment", "normal.example"),
+        ("https://[::1]", "[::1]"),
+        ("https://[::1]:8443/path", "[::1]"),
+        ("https://[::1]/path?x=1", "[::1]"),
+        ("https://[::1]/path#fragment", "[::1]"),
+    ],
+)
+@pytest.mark.parametrize(
+    "scheme_less_url",
+    [
+        "blocked.example/path",
+        "192.0.2.1:8080/path",
+    ],
+)
+async def test_urls_guardrail_blocks_scheme_less_url_after_allowlisted_url(
+    explicit_url: str,
+    allow_entry: str,
+    scheme_less_url: str,
+) -> None:
+    """An allowlisted URL cannot hide an adjacent blocked candidate."""
+    config = URLConfig(
+        url_allow_list=[allow_entry],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(
+        ctx=None,
+        data=f"{explicit_url},{scheme_less_url}",
+        config=config,
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [explicit_url, scheme_less_url]  # noqa: S101
+    assert result.info["allowed"] == [explicit_url]  # noqa: S101
+    assert result.info["blocked"] == [scheme_less_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("closer", [")", "]", "}", ">"])
+async def test_urls_guardrail_blocks_sibling_after_unmatched_closer(
+    closer: str,
+) -> None:
+    """An allowlisted open query cannot own past an unmatched closer."""
+    outer_url = "https://allow.example/?next="
+    blocked_url = "blocked.example/path"
+
+    result = await urls(
+        ctx=None,
+        data=f"{outer_url}{closer},{blocked_url}",
+        config=URLConfig(
+            url_allow_list=["allow.example"],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [outer_url, blocked_url]  # noqa: S101
+    assert result.info["allowed"] == [outer_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text, allow_entry, blocked_url",
+    [
+        (
+            "https://example.com/allowed,example.com/blocked",
+            "https://example.com/allowed",
+            "example.com/blocked",
+        ),
+        (
+            "https://192.0.2.1/allowed,203.0.113.2/blocked",
+            "192.0.2.1",
+            "203.0.113.2/blocked",
+        ),
+    ],
+)
+async def test_urls_guardrail_blocks_distinct_adjacent_destination(
+    text: str,
+    allow_entry: str,
+    blocked_url: str,
+) -> None:
+    """An allowlisted URL cannot hide a distinct adjacent destination."""
+    result = await urls(
+        ctx=None,
+        data=text,
+        config=URLConfig(url_allow_list=[allow_entry], allowed_schemes={"https"}),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "blocked_url, allowed_schemes",
+    [
+        ("ftp://blocked.example/path", {"https", "ftp"}),
+    ],
+)
+async def test_urls_guardrail_blocks_adjacent_non_http_url(
+    blocked_url: str,
+    allowed_schemes: set[str],
+) -> None:
+    """An allowlisted HTTP URL cannot hide another explicit scheme."""
+    outer_url = "https://allow.example/#frag"
+    result = await urls(
+        ctx=None,
+        data=f"{outer_url},{blocked_url}",
+        config=URLConfig(
+            url_allow_list=["allow.example"],
+            allowed_schemes=allowed_schemes,
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["allowed"] == [outer_url]  # noqa: S101
+    assert result.info["blocked"] == [blocked_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_preserves_userinfo_for_validation() -> None:
+    """Domain-shaped userinfo cannot be reinterpreted as adjacent URLs."""
+    text = "https://user:allowed.example@user/path"
+    result = await urls(
+        ctx=None,
+        data=text,
+        config=URLConfig(
+            url_allow_list=["user", "allowed.example"],
+            allowed_schemes={"https"},
+            block_userinfo=True,
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [text]  # noqa: S101
+    assert result.info["blocked"] == [text]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scheme_less_url", ["example.com", "www.example.com"])
+async def test_urls_guardrail_validates_adjacent_bare_same_host(scheme_less_url: str) -> None:
+    """A path-restricted allowlist cannot discard an adjacent bare host."""
+    explicit_url = "https://example.com/allowed"
+    result = await urls(
+        ctx=None,
+        data=f"{explicit_url},{scheme_less_url}",
+        config=URLConfig(
+            url_allow_list=[explicit_url],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["allowed"] == [explicit_url]  # noqa: S101
+    assert result.info["blocked"] == [scheme_less_url]  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_url_does_not_hide_source_distinct_blocked_host() -> None:
+    """A distinct bare host remains visible to allowlist validation."""
+    ambiguous_url = "https://allowed.example/pa\tth"
+    bare_host = "allowed.example"
+    result = await urls(
+        ctx=None,
+        data=f"{ambiguous_url} {bare_host}",
+        config=URLConfig(
+            url_allow_list=["https://allowed.example/safe"],
+            allowed_schemes={"https"},
+        ),
+    )
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [ambiguous_url, bare_host]  # noqa: S101
+    assert result.info["blocked"] == [ambiguous_url, bare_host]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prefix", ["label=(", "label=,"])
+async def test_urls_guardrail_blocks_top_level_url_after_assignment_text(prefix: str) -> None:
+    """Assignment-like prose cannot suppress a blocked bracketed URL."""
+    url = "https://[::1]/path"
+    config = URLConfig(
+        url_allow_list=[],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=f"{prefix}{url}", config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["detected"] == [url]  # noqa: S101
+    assert result.info["allowed"] == []  # noqa: S101
+    assert result.info["blocked"] == [url]  # noqa: S101
 
 
 @ASCII_URL_CONTROLS
@@ -1754,6 +3047,28 @@ def test_is_url_allowed_supports_subdomains_and_cidr() -> None:
     assert _is_url_allowed(ip_result, config.url_allow_list, config.allow_subdomains, had_scheme2) is True  # noqa: S101
 
 
+@pytest.mark.parametrize(
+    ("url", "allowed_host", "expected"),
+    [
+        ("https://www.example.com", "example.com", True),
+        ("https://example.com", "www.example.com", True),
+        ("https://notwww.example.com", "notexample.com", False),
+        ("https://sub.www.example.com", "sub.example.com", False),
+    ],
+)
+def test_is_url_allowed_removes_only_a_leading_www_label(
+    url: str,
+    allowed_host: str,
+    expected: bool,
+) -> None:
+    """Only the conventional leading www label is normalized."""
+    config = URLConfig(url_allow_list=[allowed_host], allowed_schemes={"https"})
+    parsed_url, _, had_scheme = _validate_url_security(url, config)
+
+    assert parsed_url is not None  # noqa: S101
+    assert _is_url_allowed(parsed_url, config.url_allow_list, False, had_scheme) is expected  # noqa: S101
+
+
 @pytest.mark.asyncio
 async def test_urls_guardrail_reports_allowed_and_blocked() -> None:
     """Urls guardrail should classify detected URLs based on config."""
@@ -2216,6 +3531,21 @@ async def test_urls_guardrail_handles_malformed_ports_gracefully() -> None:
     assert len(result.info["blocked"]) == 3  # noqa: S101
     # All three URLs should be blocked (the key is they don't crash the guardrail)
     assert len(result.info["blocked_reasons"]) == 3  # noqa: S101
+
+
+@pytest.mark.asyncio
+async def test_urls_guardrail_rejects_scheme_shaped_malformed_port() -> None:
+    """An invalid authority cannot become two independently allowed URLs."""
+    text = "https://example.com:https://good.example/path"
+    config = URLConfig(
+        url_allow_list=["example.com", "good.example"],
+        allowed_schemes={"https"},
+    )
+
+    result = await urls(ctx=None, data=text, config=config)
+
+    assert result.tripwire_triggered is True  # noqa: S101
+    assert result.info["blocked"] == [text]  # noqa: S101
 
 
 def test_is_url_allowed_handles_trailing_slash_in_path() -> None:


### PR DESCRIPTION
## Summary

This PR supersedes #87 while preserving its two original goals:

- detect provider-specific credentials embedded in tokens that would otherwise
  be exempt as URLs or allowed file paths;
- normalize only a genuine leading `www.` host label in the URL guardrail.

The Secret Keys guardrail now establishes structural URL and file components
before decoding them. Each component is percent-decoded at most once using
strict UTF-8 handling, then evaluated independently. This prevents unrelated
URL components, padding, or allowed file extensions from supplying the length
or diversity needed to classify a short value as a secret.

Only provider-specific forms can lift an existing URL or file exemption:

- `sk-` and `sk_`
- `ghp_`
- Slack `xoxb-` and `xoxp-`
- `SG.`
- `hf_`
- AWS access key IDs matching `AKIA` plus exactly 16 uppercase letters or
  digits

Generic prefixes such as `key-`, `api-`, `apikey-`, `token-`, and `secret-`
retain their existing standalone behavior but do not cause ordinary
high-entropy URL slugs to lose their exemption.

The URL guardrail replaces unanchored `www.` replacement with removal of
exactly one leading `www.` label at the existing normalization points.

No public API, configuration, dependency, or `custom_regex` behavior changes
are introduced.

## Relationship to #87

PR #87 introduced the component-local, decode-once approach for embedded
provider credentials and the leading-`www.` normalization fix. This PR carries
those changes forward and incorporates additional review-driven corrections.

Compared with the current #87 head (`bb4a6eb`), this version additionally:

- uses Unicode XID continuation semantics for prefix boundaries, preventing
  Unicode identifier characters such as middle dots and combining characters
  from manufacturing a secret boundary;
- preserves dotted provider prefixes such as `SG.` across parsed host labels
  and malformed-URL fallback parsing without joining ordinary non-dotted
  prefixes across labels;
- handles nested presentation wrappers and sentence punctuation adjacent to
  confirmed closing delimiters without treating the wrapper as credential
  data;
- centralizes percent-escape validation while retaining strict one-pass
  decoding;
- adds focused regression and property coverage for these boundary cases;
- brings all touched code and tests within the repository's 100-character
  limit.

## Security properties

The regression coverage verifies that:

- the reported URL-query and allowed-extension bypasses are detected;
- literal, partially encoded, mixed-case encoded, and fully encoded
  provider-specific prefixes classify consistently after one decoding pass;
- double-encoded prefixes are not decoded recursively;
- malformed escapes and invalid UTF-8 remain raw and cannot create synthetic
  boundaries;
- URL components are scored independently;
- query punctuation and encoded separators inside a candidate remain candidate
  data;
- Unicode XID continuations do not create prefix boundaries, while genuine
  punctuation can;
- valid AWS access key IDs are detected without flagging ordinary `AKIA`
  strings or longer identifier continuations;
- generic natural-language URL slugs remain exempt;
- parsed and malformed URLs handle `SG.` consistently;
- nested presentation punctuation does not complete a short candidate;
- terminal URI punctuation remains credential data when it is not part of a
  confirmed presentation wrapper;
- findings continue to report the original whitespace token once.
