### PR TITLE
fix: make URL domain detection linear

### DIFF
--- a/src/guardrails/checks/text/urls.py
+++ b/src/guardrails/checks/text/urls.py
@@ -41,6 +41,8 @@ DEFAULT_PORTS = {
 }
 
 SCHEME_PREFIX_RE = re.compile(r"^[a-z][a-z0-9+.-]*://")
+DOMAIN_HOST_CANDIDATE_RE = re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9.-]*")
+ASCII_LETTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,6 +107,63 @@ class URLConfig(BaseModel):
         return normalized
 
 
+def _find_domain_end(host_candidate: str) -> int | None:
+    """Find the end of the last valid domain suffix in a host candidate.
+
+    Args:
+        host_candidate: Maximal ASCII hostname-shaped text to inspect.
+
+    Returns:
+        The exclusive end offset of the last dot followed by at least two
+        ASCII letters, or ``None`` when no valid suffix exists.
+    """
+    domain_end = None
+
+    for index, character in enumerate(host_candidate):
+        if character != ".":
+            continue
+
+        suffix_end = index + 1
+        while suffix_end < len(host_candidate) and host_candidate[suffix_end] in ASCII_LETTERS:
+            suffix_end += 1
+
+        if suffix_end - index > 2:
+            domain_end = suffix_end
+
+    return domain_end
+
+
+def _detect_domain_like_urls(text: str) -> list[str]:
+    """Detect scheme-less domain-like URLs in linear time.
+
+    Args:
+        text: Text to scan for domain-like URLs.
+
+    Returns:
+        Domain-like URL matches using the existing detection semantics.
+    """
+    detected_domains: list[str] = []
+    search_position = 0
+
+    while match := DOMAIN_HOST_CANDIDATE_RE.search(text, search_position):
+        host_candidate = match.group(0)
+        domain_end = _find_domain_end(host_candidate)
+        if domain_end is None:
+            search_position = match.end()
+            continue
+
+        match_end = match.start() + domain_end
+        if domain_end == len(host_candidate) and match_end < len(text) and text[match_end] == "/":
+            match_end += 1
+            while match_end < len(text) and not text[match_end].isspace():
+                match_end += 1
+
+        detected_domains.append(text[match.start() : match_end])
+        search_position = match_end
+
+    return detected_domains
+
+
 def _detect_urls(text: str) -> list[str]:
     """Detect URLs using regex patterns with deduplication.
 
@@ -148,8 +207,7 @@ def _detect_urls(text: str) -> list[str]:
                     scheme_urls.add(domain_part.lower())
 
     # Pattern 2: Domain-like patterns (scheme-less) - but skip if already found with scheme
-    domain_pattern = r"\b(?:www\.)?[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}(?:/[^\s]*)?"
-    domain_matches = re.findall(domain_pattern, text, re.IGNORECASE)
+    domain_matches = _detect_domain_like_urls(text)
 
     for match in domain_matches:
         # Clean trailing punctuation

--- a/src/guardrails/checks/text/urls.py
+++ b/src/guardrails/checks/text/urls.py
@@ -41,8 +41,9 @@ DEFAULT_PORTS = {
 }
 
 SCHEME_PREFIX_RE = re.compile(r"^[a-z][a-z0-9+.-]*://")
-DOMAIN_HOST_CANDIDATE_RE = re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9.-]*")
+DOMAIN_HOST_CANDIDATE_RE = re.compile(r"\b[a-zA-Z0-9][a-zA-Z0-9.-]*", re.IGNORECASE)
 ASCII_LETTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+CASE_INSENSITIVE_ASCII_LETTERS = ASCII_LETTERS | frozenset("İıſK")
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,7 +125,9 @@ def _find_domain_end(host_candidate: str) -> int | None:
             continue
 
         suffix_end = index + 1
-        while suffix_end < len(host_candidate) and host_candidate[suffix_end] in ASCII_LETTERS:
+        while suffix_end < len(host_candidate):
+            if host_candidate[suffix_end] not in CASE_INSENSITIVE_ASCII_LETTERS:
+                break
             suffix_end += 1
 
         if suffix_end - index > 2:

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -2,15 +2,72 @@
 
 from __future__ import annotations
 
+import re
+import string
+from time import perf_counter
+
 import pytest
+from hypothesis import given, strategies as st
 
 from guardrails.checks.text.urls import (
     URLConfig,
+    _detect_domain_like_urls,
     _detect_urls,
     _is_url_allowed,
     _validate_url_security,
     urls,
 )
+
+REFERENCE_DOMAIN_PATTERN = re.compile(
+    r"\b(?:www\.)?[a-zA-Z0-9][a-zA-Z0-9.-]*\.[a-zA-Z]{2,}(?:/[^\s]*)?",
+    re.IGNORECASE,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("foo.com-", ["foo.com"]),
+        ("foo.com123", ["foo.com"]),
+        ("foo.c0m", []),
+        ("foo.com.a", ["foo.com"]),
+        ("foo..example.com", ["foo..example.com"]),
+        ("-example.com", ["example.com"]),
+        ("_example.com", []),
+        ("foo.com-evil/path", ["foo.com"]),
+        ("foo.com/path?x=1", ["foo.com/path?x=1"]),
+        ("abc/example.com", ["example.com"]),
+    ],
+)
+def test_detect_domain_like_urls_preserves_existing_matches(
+    text: str,
+    expected: list[str],
+) -> None:
+    """The linear scanner should preserve established domain matching."""
+    assert _detect_domain_like_urls(text) == expected  # noqa: S101
+
+
+@given(
+    text=st.text(
+        alphabet=string.ascii_letters + string.digits + string.punctuation + " \t\n\r",
+        max_size=100,
+    )
+)
+def test_detect_domain_like_urls_matches_reference_pattern(text: str) -> None:
+    """The linear scanner should match the previous regex on bounded text."""
+    assert _detect_domain_like_urls(text) == REFERENCE_DOMAIN_PATTERN.findall(text)  # noqa: S101
+
+
+def test_detect_urls_handles_large_invalid_domain_input_quickly() -> None:
+    """Invalid dotted input should not cause quadratic regex backtracking."""
+    text = "a." * 16_000 + "-"
+
+    started_at = perf_counter()
+    detected = _detect_urls(text)
+    duration_seconds = perf_counter() - started_at
+
+    assert detected == []  # noqa: S101
+    assert duration_seconds < 1.0  # noqa: S101
 
 
 def test_detect_urls_deduplicates_scheme_and_domain() -> None:

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -37,6 +37,12 @@ REFERENCE_DOMAIN_PATTERN = re.compile(
         ("foo.com-evil/path", ["foo.com"]),
         ("foo.com/path?x=1", ["foo.com/path?x=1"]),
         ("abc/example.com", ["example.com"]),
+        ("example.cİ", ["example.cİ"]),
+        ("example.cı", ["example.cı"]),
+        ("example.cſ", ["example.cſ"]),
+        ("example.cK", ["example.cK"]),
+        ("K.example.com", ["K.example.com"]),
+        ("foo.ſſ/path", ["foo.ſſ/path"]),
     ],
 )
 def test_detect_domain_like_urls_preserves_existing_matches(
@@ -49,7 +55,7 @@ def test_detect_domain_like_urls_preserves_existing_matches(
 
 @given(
     text=st.text(
-        alphabet=string.ascii_letters + string.digits + string.punctuation + " \t\n\r",
+        alphabet=string.ascii_letters + string.digits + string.punctuation + "İıſK \t\n\r",
         max_size=100,
     )
 )
@@ -68,6 +74,11 @@ def test_detect_urls_handles_large_invalid_domain_input_quickly() -> None:
 
     assert detected == []  # noqa: S101
     assert duration_seconds < 1.0  # noqa: S101
+
+
+def test_detect_urls_preserves_unicode_casefolded_domain() -> None:
+    """Unicode characters matched by the previous regex remain detectable."""
+    assert _detect_urls("Visit attacker.cK now") == ["attacker.cK"]  # noqa: S101
 
 
 def test_detect_urls_deduplicates_scheme_and_domain() -> None:

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import re
 import string
-from time import perf_counter
+from statistics import median
+from timeit import repeat
 
 import pytest
 from hypothesis import given, strategies as st
@@ -64,16 +65,17 @@ def test_detect_domain_like_urls_matches_reference_pattern(text: str) -> None:
     assert _detect_domain_like_urls(text) == REFERENCE_DOMAIN_PATTERN.findall(text)  # noqa: S101
 
 
-def test_detect_urls_handles_large_invalid_domain_input_quickly() -> None:
-    """Invalid dotted input should not cause quadratic regex backtracking."""
-    text = "a." * 16_000 + "-"
+def test_detect_urls_scales_linearly_for_invalid_domain_input() -> None:
+    """Doubling invalid dotted input should not cause quadratic growth."""
+    small_text = "a." * 2_000 + "-"
+    large_text = "a." * 4_000 + "-"
 
-    started_at = perf_counter()
-    detected = _detect_urls(text)
-    duration_seconds = perf_counter() - started_at
+    small_duration = median(repeat(lambda: _detect_urls(small_text), number=1, repeat=7))
+    large_duration = median(repeat(lambda: _detect_urls(large_text), number=1, repeat=7))
 
-    assert detected == []  # noqa: S101
-    assert duration_seconds < 1.0  # noqa: S101
+    assert _detect_urls(small_text) == []  # noqa: S101
+    assert _detect_urls(large_text) == []  # noqa: S101
+    assert large_duration < small_duration * 3  # noqa: S101
 
 
 def test_detect_urls_preserves_unicode_casefolded_domain() -> None:


### PR DESCRIPTION
## Problem

The URL Filter used a backtracking regular expression to detect scheme-less domains. Inputs with long dotted runs that never ended in a valid top-level domain caused quadratic matching time, allowing untrusted text to block the synchronous guardrail path for a disproportionate amount of time.

## Solution

Replace the backtracking domain expression with a linear-time scanner that first identifies maximal hostname-shaped candidates and then locates the last valid ASCII domain suffix in a single bounded pass. The scanner preserves the previous matching behavior, including partial matches and path handling, while avoiding repeated suffix backtracking.

Add regression coverage for existing edge cases, property-based equivalence against the previous expression on bounded inputs, and a large invalid dotted-input performance case.