### PR TITLE
version 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openai-guardrails"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenAI Guardrails: A framework for building safe and reliable AI systems."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release readiness review

`v0.3.0` -> `release/0.3.1` (`f10e43ffd7b9a7b9b72192532ab1bc5719e18a0e`)

Diff: https://github.com/openai/openai-guardrails-python/compare/v0.3.0...f10e43ffd7b9a7b9b72192532ab1bc5719e18a0e

### Release intent

- Review mode: final candidate
- Intended release: `0.3.1` / patch
- Minimum required release type: patch
- Versioning verdict: compatible

### Release call

**🟢 GREEN LIGHT TO SHIP**

The candidate matches `origin/release/0.3.1`, the working tree is clean, and no release blocker was identified.

### Scope summary

28 files changed (+13,975/-381). Most additions are agent workflow tooling and tests. User-visible runtime changes are limited to URL filtering, secret detection, keyword validation, and Python 3.14 dependency resolution.

### Risk assessment

1. **URL Filter security hardening**
   - Risk: **🟢 LOW**. Control-bearing and parser-ambiguous URLs now fail closed while preserving valid allow-list behavior.
   - Evidence: The implementation covers ASCII controls, scheme-less URLs, userinfo, adjacent URLs, exact component identity, and linear-time scanning.
   - Files: `src/guardrails/checks/text/urls.py`, `tests/unit/checks/test_urls.py`
   - Action: Preserve the exact fail-closed behavior and performance properties in the release.

2. **Secret Keys exemption hardening**
   - Risk: **🟢 LOW**. Supported provider credentials embedded in HTTP(S) query values or final file basenames are no longer hidden by broad URL/file exemptions.
   - Evidence: Percent encoding uses strict single-pass UTF-8 decoding. Nested URLs, malformed URLs, fragments, userinfo, and intermediate path segments remain intentionally unsupported.
   - Files: `src/guardrails/checks/text/secret_keys.py`, `tests/unit/checks/test_secret_keys.py`
   - Action: Retain the deliberately narrow supported-container contract.

3. **Keyword configuration validation**
   - Risk: **🟢 LOW**. Keywords that become empty after punctuation sanitization now fail during configuration instead of producing match-all-like behavior.
   - Evidence: Validation is confined to previously invalid punctuation-only values.
   - Files: `src/guardrails/checks/text/keywords.py`, `tests/unit/checks/test_keywords.py`
   - Action: No release change required.

4. **Python 3.14 spaCy resolution**
   - Risk: **🟢 LOW**. Python 3.14 now selects the known-good `spacy==3.8.13`; other Python versions are unaffected.
   - Evidence: Locally built wheel and sdist both declare version `0.3.1`, Python `>=3.11`, and the correct conditional dependency.
   - Files: `pyproject.toml`
   - Action: Deliberately validate a newer spaCy release before relaxing the Python 3.14 pin.

### CI and packaging readiness

- Runtime head `a18d176e...` passed CI on Python 3.11, 3.12, 3.13, and 3.14, plus docs deployment.
- The release SHA has no separate check run, but its only difference from the green main SHA is the one-line version bump.
- Candidate wheel and sdist builds completed successfully with the expected metadata.
- The working tree remains clean.
- The local full test suite was not rerun because the exact runtime content already passed the complete remote matrix.

This green gate applies only to `f10e43ffd7b9a7b9b72192532ab1bc5719e18a0e`. Any candidate, version, or dependency change invalidates the result and requires another review.