### PR TITLE
chore: restrict GitHub Actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,12 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   lint-and-test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -14,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,8 +9,7 @@ on:
     - cron: '23 8 * * 1'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,10 +5,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: "pages"
@@ -16,6 +13,10 @@ concurrency:
 
 jobs:
   deploy_docs:
+    permissions:
+      contents: read
+      pages: write # Deploy the documentation site.
+      id-token: write # Authenticate the Pages deployment.
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -23,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,7 @@ on:
     types:
       - published
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   publish:
@@ -14,12 +13,15 @@ jobs:
       name: pypi
       url: https://pypi.org/p/openai-guardrails
     permissions:
+      contents: read
       id-token: write # Important for trusted publishing to PyPI
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:


### PR DESCRIPTION
## Summary

Set every workflow's default token permissions to `permissions: {}` and explicitly grant only the scopes each existing job needs. Disable persisted checkout credentials. All 14 direct action references already use full commit SHA pins and remain unchanged.

Repository settings have also been changed to read-only contents/packages by default, with Actions PR creation and approval disabled. Full-SHA enforcement was already enabled.

## Validation

- Two consecutive clean rounds of independent adversarial review.
- Actionlint, formatting, and lint passed.
- All 1,338 tests passed.
- Existing type-check failures remain in unchanged Python code: 487 Mypy errors and 241 Pyright errors. No runtime or typing changes are included.