### PR TITLE
chore: Run required checks for merge queue groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions: {}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: '23 8 * * 1'
   workflow_dispatch:


### PR DESCRIPTION
This pull request updates CI and CodeQL to run on `merge_group` events so all six existing required checks report results for queued merges. Existing triggers, job names, permissions, and execution behavior are preserved.

Merge this prerequisite before enabling the merge queue in the `main` ruleset.

Validation: both workflow files parse as YAML and differ from the base only by the new trigger. Independent implementation/security review and two adversarial review rounds passed. Local lint passed; the broad verification wrapper stopped on 487 mypy errors across 35 unchanged Python files. Unrelated formatter changes were discarded.