### PR TITLE
fix: Match safety identifier endpoints by hostname

### DIFF
--- a/src/guardrails/utils/safety_identifier.py
+++ b/src/guardrails/utils/safety_identifier.py
@@ -10,6 +10,7 @@ be sent to Azure OpenAI or other OpenAI-compatible providers.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 if TYPE_CHECKING:
     from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
@@ -59,9 +60,8 @@ def supports_safety_identifier(
     # Check if using a custom base_url (local or alternative provider)
     base_url = getattr(client, "base_url", None)
     if base_url is not None:
-        base_url_str = str(base_url)
         # Only official OpenAI API endpoints support safety_identifier
-        return "api.openai.com" in base_url_str
+        return urlsplit(str(base_url)).hostname == "api.openai.com"
 
     # Default OpenAI client (no custom base_url) supports it
     return True

--- a/src/guardrails/utils/safety_identifier.py
+++ b/src/guardrails/utils/safety_identifier.py
@@ -61,7 +61,8 @@ def supports_safety_identifier(
     base_url = getattr(client, "base_url", None)
     if base_url is not None:
         # Only official OpenAI API endpoints support safety_identifier
-        return urlsplit(str(base_url)).hostname == "api.openai.com"
+        hostname = urlsplit(str(base_url)).hostname or ""
+        return hostname == "api.openai.com" or hostname.endswith(".api.openai.com")
 
     # Default OpenAI client (no custom base_url) supports it
     return True

--- a/tests/unit/test_safety_identifier.py
+++ b/tests/unit/test_safety_identifier.py
@@ -3,6 +3,24 @@
 from unittest.mock import Mock
 
 import pytest
+from httpx import URL
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("https://api.openai.com/v1", True),
+        ("https://API.OPENAI.COM/v1", True),
+        ("http://localhost:11434/v1", False),
+        ("http://localhost:11434/api.openai.com/v1", False),
+    ],
+)
+def test_safety_identifier_uses_client_hostname(base_url: str, expected: bool) -> None:
+    """Classify SDK URL objects by hostname independently of routing paths."""
+    from guardrails.utils.safety_identifier import supports_safety_identifier
+
+    client = Mock(base_url=URL(base_url))
+    assert supports_safety_identifier(client) is expected
 
 
 def test_supports_safety_identifier_for_openai_client() -> None:

--- a/tests/unit/test_safety_identifier.py
+++ b/tests/unit/test_safety_identifier.py
@@ -11,6 +11,10 @@ from httpx import URL
     [
         ("https://api.openai.com/v1", True),
         ("https://API.OPENAI.COM/v1", True),
+        ("https://eu.api.openai.com/v1", True),
+        ("https://us.api.openai.com/v1", True),
+        ("https://notapi.openai.com/v1", False),
+        ("https://api.openai.com.example.org/v1", False),
         ("http://localhost:11434/v1", False),
         ("http://localhost:11434/api.openai.com/v1", False),
     ],


### PR DESCRIPTION
This pull request fixes endpoint classification for the automatic safety identifier by checking the parsed hostname against `api.openai.com` and its dot-delimited subdomains. This preserves official regional endpoints while preventing custom provider routing paths or unrelated hostnames from enabling the OpenAI-only parameter. Default-client and Azure handling remain unchanged.

Regression coverage includes apex and regional hosts, uppercase hostnames, local routing paths, and unrelated domain boundaries. Validation: all 1,348 tests, Ruff, Mypy, and Pyright pass.