### PR TITLE
fix: retain masked input in PII example history

### DIFF
--- a/examples/basic/pii_mask_example.py
+++ b/examples/basic/pii_mask_example.py
@@ -94,6 +94,7 @@ async def process_input(
         console.print(f"\n[bold blue]Assistant output:[/bold blue] {content}\n")
 
         # Show PII masking information if detected in pre-flight
+        masked_text = user_input
         if response.guardrail_results.preflight:
             for result in response.guardrail_results.preflight:
                 if result.info.get("guardrail_name") == "Contains PII" and result.info.get("pii_detected", False):
@@ -125,8 +126,8 @@ async def process_input(
                         )
                     )
 
-        # Guardrails passed - now safe to add to conversation history
-        messages.append({"role": "user", "content": user_input})
+        # Retain the masked input so later turns do not resend the original PII.
+        messages.append({"role": "user", "content": masked_text})
         messages.append({"role": "assistant", "content": content})
 
     except GuardrailTripwireTriggered as exc:

--- a/tests/unit/test_pii_mask_example.py
+++ b/tests/unit/test_pii_mask_example.py
@@ -1,0 +1,72 @@
+"""Conversation-history contract for the interactive PII masking example."""
+
+import runpy
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from guardrails import GuardrailTripwireTriggered
+from guardrails.types import GuardrailResult
+
+
+@pytest.fixture
+def example() -> dict[str, Any]:
+    return runpy.run_path(str(Path(__file__).resolve().parents[2] / "examples/basic/pii_mask_example.py"))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("preflight", "expected"),
+    [
+        (
+            [GuardrailResult(False, info={"guardrail_name": "Contains PII", "pii_detected": True, "checked_text": "<EMAIL_ADDRESS>"})],
+            "<EMAIL_ADDRESS>",
+        ),
+        ([GuardrailResult(False, info={"guardrail_name": "Contains PII", "pii_detected": False})], "sample input"),
+        ([], "sample input"),
+    ],
+)
+async def test_successful_turn_retains_checked_input(example: dict[str, Any], preflight: list[GuardrailResult], expected: str) -> None:
+    response = MagicMock()
+    response.choices[0].message.content = "How can I help?"
+    response.guardrail_results.preflight = preflight
+    response.guardrail_results.output = []
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(return_value=response)
+    history = [{"role": "system", "content": "Be helpful."}]
+
+    await example["process_input"](client, "sample input", history)
+
+    assert history == [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": expected},
+        {"role": "assistant", "content": "How can I help?"},
+    ]
+    response.guardrail_results.preflight = []
+    await example["process_input"](client, "next turn", history)
+
+    assert client.chat.completions.create.await_args_list[1].kwargs["messages"] == [
+        {"role": "system", "content": "Be helpful."},
+        {"role": "user", "content": expected},
+        {"role": "assistant", "content": "How can I help?"},
+        {"role": "user", "content": "next turn"},
+    ]
+    assert history[-2:] == [
+        {"role": "user", "content": "next turn"},
+        {"role": "assistant", "content": "How can I help?"},
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [RuntimeError("provider unavailable"), GuardrailTripwireTriggered(GuardrailResult(True))])
+async def test_failed_turn_preserves_history(example: dict[str, Any], error: Exception) -> None:
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=error)
+    history = [{"role": "system", "content": "Be helpful."}]
+
+    with pytest.raises(type(error)):
+        await example["process_input"](client, "sample input", history)
+
+    assert history == [{"role": "system", "content": "Be helpful."}]


### PR DESCRIPTION
This pull request fixes the PII masking example retaining original user input after a successful masked request, which allowed later turns to resend that input as history. Retain the existing preflight checked text for subsequent requests and add regression coverage for masked and ordinary turns plus failure handling. SDK APIs, configuration, and failure behavior remain unchanged.

Validation: formatting, lint, mypy, pyright, and all 1,345 tests pass. Two consecutive independent review rounds on the rebased commit found no blocking issues.