### PR TITLE
fix: bound secret-key extension matching work

### DIFF
--- a/src/guardrails/checks/text/secret_keys.py
+++ b/src/guardrails/checks/text/secret_keys.py
@@ -288,10 +288,10 @@ def _contains_allowed_pattern(text: str) -> bool:
     if url_pattern.search(text):
         return True
 
-    # Regex for allowed file extensions
-    # Build a pattern like: ".*\\.(py|js|html|...|png)$"
+    # Require a non-whitespace stem character without rescanning a greedy
+    # prefix at every search position when no allowed extension matches.
     ext_pattern = re.compile(
-        r"[^\s]+(" + "|".join(re.escape(ext) for ext in ALLOWED_EXTENSIONS) + r")$",
+        r"(?<=\S)(" + "|".join(re.escape(ext) for ext in ALLOWED_EXTENSIONS) + r")$",
         re.IGNORECASE,
     )
     if ext_pattern.search(text):

--- a/tests/unit/checks/test_secret_keys.py
+++ b/tests/unit/checks/test_secret_keys.py
@@ -42,6 +42,30 @@ async def test_secret_keys_ignores_non_matching_input() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("text", "exempt"),
+    [
+        ("AbCdEfGhIjKlMnOpQrStUvWx012345.py", True),
+        ("AbCdEfGhIjKlMnOpQrStUvWx012345.PY", True),
+        ("AbCdEfGhIjKlMnOpQrStUvWx012345.jſ", True),
+        ("folder/AbCdEfGhIjKlMnOpQrStUvWx012345.json", True),
+        ("AbCdEfGhIjKlMnOpQrStUvWx012345.py\n", True),
+        ("https://example.com/report.unknown", True),
+        ("AbCdEfGhIjKlMnOpQrStUvWx012345.unknown", False),
+        ("AbCdEfGhIjKlMnOpQrStUvWx012345.py.backup", False),
+    ],
+)
+@pytest.mark.parametrize("threshold", ["balanced", "permissive", "strict"])
+async def test_secret_keys_preserves_extension_exemption_semantics(text: str, exempt: bool, threshold: str) -> None:
+    """Only non-strict checks exempt recognized suffixes with a nonempty stem."""
+    result = await secret_keys(None, text, SecretKeysCfg(threshold=threshold, custom_regex=None))
+
+    expected_secrets = [] if exempt and threshold != "strict" else [text.strip()]
+    assert result.tripwire_triggered is bool(expected_secrets)
+    assert result.info["detected_secrets"] == expected_secrets
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "text",
     [
         "https://example.com/?token=sk-AAAABBBBCCCCDDDD",


### PR DESCRIPTION
This pull request fixes repeated prefix scanning in Secret Keys file-extension matching by replacing the greedy prefix with a fixed-width lookbehind. This preserves existing classification, including nonempty stems, case-insensitive suffixes, URL exemptions, and threshold behavior, while keeping extension matching linear in token length. Public regression tests cover the preserved behavior across all three thresholds.