### PR TITLE
fix: mask repeated encoded PII in structured content

### DIFF
--- a/src/guardrails/_base_client.py
+++ b/src/guardrails/_base_client.py
@@ -361,112 +361,22 @@ class GuardrailsBaseClient:
         Returns:
             Modified messages with PII masking applied to each text part
         """
-        from guardrails.utils.anonymizer import OperatorConfig, anonymize
+        from .checks.text.pii import PIIConfig, PIIEntity, _detect_pii, _mask_pii
 
-        # Extract detected entity types and config
         detected = pii_result.info.get("detected_entities", {})
         if not detected:
             return data
 
-        detect_encoded_pii = pii_result.info.get("detect_encoded_pii", False)
-
-        # Get analyzer engine - entity types are guaranteed valid from detection
-        from .checks.text.pii import _get_analyzer_engine
-
-        analyzer = _get_analyzer_engine()
-        entity_types = list(detected.keys())
-
-        # Create operators for each entity type
-        operators = {entity_type: OperatorConfig("replace", {"new_value": f"<{entity_type}>"}) for entity_type in entity_types}
-
         def _mask_text(text: str) -> str:
-            """Mask using custom anonymizer with Unicode normalization.
-
-            Handles both plain and encoded PII consistently with main detection path.
-            """
+            """Use the main masking pipeline so each encoded span is replaced once."""
             if not text:
                 return text
-
-            # Import functions from pii module
-            from .checks.text.pii import EncodedCandidate, _build_decoded_text, _normalize_unicode
-
-            # Normalize to prevent bypasses
-            normalized = _normalize_unicode(text)
-
-            # Check for plain PII
-            analyzer_results = analyzer.analyze(normalized, entities=entity_types, language="en")
-            has_plain_pii = bool(analyzer_results)
-
-            # Check for encoded PII if enabled
-            has_encoded_pii = False
-            encoded_candidates: list[EncodedCandidate] = []
-
-            if detect_encoded_pii:
-                decoded_text, encoded_candidates = _build_decoded_text(normalized)
-                if encoded_candidates:
-                    # Analyze decoded text
-                    decoded_results = analyzer.analyze(decoded_text, entities=entity_types, language="en")
-                    has_encoded_pii = bool(decoded_results)
-
-            # If no PII found at all, return original text
-            if not has_plain_pii and not has_encoded_pii:
-                return text
-
-            # Mask plain PII
-            masked = normalized
-            if has_plain_pii:
-                masked = anonymize(text=masked, analyzer_results=analyzer_results, operators=operators).text
-
-            # Mask encoded PII if found
-            if has_encoded_pii:
-                # Re-analyze to get positions in the (potentially) masked text
-                decoded_text_for_masking, candidates_for_masking = _build_decoded_text(masked)
-                decoded_results = analyzer.analyze(decoded_text_for_masking, entities=entity_types, language="en")
-
-                if decoded_results:
-                    # Build list of (candidate, entity_type) pairs to mask
-                    candidates_to_mask = []
-
-                    for result in decoded_results:
-                        detected_value = decoded_text_for_masking[result.start : result.end]
-                        entity_type = result.entity_type
-
-                        # Find candidate that overlaps with this PII
-                        # Use comprehensive overlap logic matching pii.py implementation
-                        for candidate in candidates_for_masking:
-                            if not candidate.decoded_text:
-                                continue
-
-                            candidate_lower = candidate.decoded_text.lower()
-                            detected_lower = detected_value.lower()
-
-                            # Check if candidate's decoded text overlaps with the detection
-                            # Handle partial encodings where encoded span may include extra characters
-                            # e.g., %3A%6a%6f%65%40 → ":joe@" but only "joe@" is in email "joe@domain.com"
-                            has_overlap = (
-                                candidate_lower in detected_lower  # Candidate is substring of detection
-                                or detected_lower in candidate_lower  # Detection is substring of candidate
-                                or (
-                                    len(candidate_lower) >= 3
-                                    and any(  # Any 3-char chunk overlaps
-                                        candidate_lower[i : i + 3] in detected_lower for i in range(len(candidate_lower) - 2)
-                                    )
-                                )
-                            )
-
-                            if has_overlap:
-                                candidates_to_mask.append((candidate, entity_type))
-                                break
-
-                    # Sort by position (reverse) to mask from end to start
-                    # This preserves position validity for subsequent replacements
-                    candidates_to_mask.sort(key=lambda x: x[0].start, reverse=True)
-
-                    # Mask from end to start
-                    for candidate, entity_type in candidates_to_mask:
-                        entity_marker = f"<{entity_type}_ENCODED>"
-                        masked = masked[: candidate.start] + entity_marker + masked[candidate.end :]
-
+            config = PIIConfig(
+                entities=[PIIEntity(entity_type) for entity_type in detected],
+                detect_encoded_pii=pii_result.info.get("detect_encoded_pii", False),
+            )
+            detection = _detect_pii(text, config)
+            masked, _ = _mask_pii(text, detection, config)
             return masked
 
         # Mask each text part

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -80,7 +80,7 @@ import unicodedata
 import urllib.parse
 from collections import defaultdict
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, Final
@@ -480,6 +480,8 @@ class EncodedCandidate:
         encoding_type: Type of encoding (base64, url, hex).
         start: Start position in original text.
         end: End position in original text.
+        decoded_start: Start position in the fully decoded text.
+        decoded_end: End position in the fully decoded text.
     """
 
     encoded_text: str
@@ -487,6 +489,8 @@ class EncodedCandidate:
     encoding_type: str
     start: int
     end: int
+    decoded_start: int = 0
+    decoded_end: int = 0
 
 
 def _try_decode_base64(text: str) -> str | None:
@@ -630,9 +634,25 @@ def _build_decoded_text(text: str) -> tuple[str, list[EncodedCandidate]]:
                         end=match.end(),
                     )
                 )
-        decoded_text = url_decoded
+    # Convert original spans to positions after both decoding stages. Only
+    # Base64/hex replacements shift positions before the URL decoding pass.
+    positioned_candidates = []
+    shift = 0
+    for candidate in sorted(candidates, key=lambda c: c.start):
+        start = candidate.start + shift
+        replacement_length = len(candidate.decoded_text or "") if candidate.encoding_type != "url" else candidate.end - candidate.start
+        end = start + replacement_length
+        positioned_candidates.append(
+            replace(
+                candidate,
+                decoded_start=len(urllib.parse.unquote(decoded_text[:start])),
+                decoded_end=len(urllib.parse.unquote(decoded_text[:end])),
+            )
+        )
+        if candidate.encoding_type != "url":
+            shift += replacement_length - (candidate.end - candidate.start)
 
-    return decoded_text, candidates
+    return url_decoded, positioned_candidates
 
 
 def _mask_pii(text: str, detection: PiiDetectionResult, config: PIIConfig) -> tuple[str, dict[str, list[str]]]:
@@ -735,25 +755,9 @@ def _mask_encoded_pii(text: str, config: PIIConfig, original_text: str | None = 
 
         found_entities = set()
         for res in analyzer_results:
-            detected_value = decoded_text[res.start : res.end]
-            candidate_lower = candidate.decoded_text.lower()
-            detected_lower = detected_value.lower()
-
-            # Check if candidate's decoded text overlaps with the detection
-            # Handle partial encodings where encoded span may include extra characters
-            # e.g., %3A%6a%6f%65%40 → ":joe@" but only "joe@" is in email "joe@domain.com"
-            has_overlap = (
-                candidate_lower in detected_lower  # Candidate is substring of detection
-                or detected_lower in candidate_lower  # Detection is substring of candidate
-                or (
-                    len(candidate_lower) >= 3
-                    and any(  # Any 3-char chunk overlaps
-                        candidate_lower[i : i + 3] in detected_lower for i in range(len(candidate_lower) - 2)
-                    )
-                )
-            )
-
-            if has_overlap:
+            # Associate detections with their actual span, not similar text
+            # elsewhere in the message (including partial URL encodings).
+            if candidate.decoded_start < res.end and res.start < candidate.decoded_end:
                 found_entities.add(res.entity_type)
                 encoded_detections[res.entity_type].append(candidate.encoded_text)
 

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -638,17 +638,25 @@ def _build_decoded_text(text: str) -> tuple[str, list[EncodedCandidate]]:
     # Base64/hex replacements shift positions before the URL decoding pass.
     positioned_candidates = []
     shift = 0
+    previous_end = 0
+    decoded_position = 0
     for candidate in sorted(candidates, key=lambda c: c.start):
         start = candidate.start + shift
         replacement_length = len(candidate.decoded_text or "") if candidate.encoding_type != "url" else candidate.end - candidate.start
         end = start + replacement_length
+        # Decode disjoint spans so position tracking does not repeatedly scan
+        # growing prefixes when input contains many short percent escapes.
+        decoded_position += len(urllib.parse.unquote(decoded_text[previous_end:start]))
+        decoded_start = decoded_position
+        decoded_position += len(urllib.parse.unquote(decoded_text[start:end]))
         positioned_candidates.append(
             replace(
                 candidate,
-                decoded_start=len(urllib.parse.unquote(decoded_text[:start])),
-                decoded_end=len(urllib.parse.unquote(decoded_text[:end])),
+                decoded_start=decoded_start,
+                decoded_end=decoded_position,
             )
         )
+        previous_end = end
         if candidate.encoding_type != "url":
             shift += replacement_length - (candidate.end - candidate.start)
 

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -73,6 +73,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import codecs
 import functools
 import logging
 import re
@@ -552,6 +553,32 @@ def _try_decode_hex(text: str) -> str | None:
         return None
 
 
+def _url_decoded_offsets(text: str) -> list[int]:
+    """Map source boundaries to URL-decoded prefix lengths in one pass."""
+    offsets = [0]
+    decoded_length = 0
+    cursor = 0
+    for match in _URL_ENCODED_PATTERN.finditer(text):
+        gap_length = match.start() - cursor
+        offsets.extend(range(decoded_length + 1, decoded_length + gap_length + 1))
+        decoded_length += gap_length
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        pending_length = 0
+        for index in range(match.start(), match.end(), 3):
+            # A prefix ending inside %HH retains its literal '%' or '%H'.
+            # Keep incomplete UTF-8 bytes buffered for following escapes, but
+            # count their errors='replace' output when measuring a prefix.
+            prefix_length = decoded_length + pending_length
+            offsets.extend((prefix_length + 1, prefix_length + 2))
+            decoded_length += len(decoder.decode(bytes.fromhex(text[index + 1 : index + 3])))
+            pending_length = len(decoder.getstate()[0].decode("utf-8", errors="replace"))
+            offsets.append(decoded_length + pending_length)
+        decoded_length += len(decoder.decode(b"", final=True))
+        cursor = match.end()
+    offsets.extend(range(decoded_length + 1, decoded_length + len(text) - cursor + 1))
+    return offsets
+
+
 def _build_decoded_text(text: str) -> tuple[str, list[EncodedCandidate]]:
     """Build a fully decoded version of text by decoding all encoded chunks.
 
@@ -638,25 +665,18 @@ def _build_decoded_text(text: str) -> tuple[str, list[EncodedCandidate]]:
     # Base64/hex replacements shift positions before the URL decoding pass.
     positioned_candidates = []
     shift = 0
-    previous_end = 0
-    decoded_position = 0
+    offsets = _url_decoded_offsets(decoded_text) if candidates else []
     for candidate in sorted(candidates, key=lambda c: c.start):
         start = candidate.start + shift
         replacement_length = len(candidate.decoded_text or "") if candidate.encoding_type != "url" else candidate.end - candidate.start
         end = start + replacement_length
-        # Decode disjoint spans so position tracking does not repeatedly scan
-        # growing prefixes when input contains many short percent escapes.
-        decoded_position += len(urllib.parse.unquote(decoded_text[previous_end:start]))
-        decoded_start = decoded_position
-        decoded_position += len(urllib.parse.unquote(decoded_text[start:end]))
         positioned_candidates.append(
             replace(
                 candidate,
-                decoded_start=decoded_start,
-                decoded_end=decoded_position,
+                decoded_start=offsets[start],
+                decoded_end=offsets[end],
             )
         )
-        previous_end = end
         if candidate.encoding_type != "url":
             shift += replacement_length - (candidate.end - candidate.start)
 

--- a/src/guardrails/checks/text/pii.py
+++ b/src/guardrails/checks/text/pii.py
@@ -632,10 +632,19 @@ def _build_decoded_text(text: str) -> tuple[str, list[EncodedCandidate]]:
             )
             used_spans.add((match.start(), match.end()))
 
-    # Build fully decoded text by replacing Hex and Base64 chunks first
-    candidates.sort(key=lambda c: c.start, reverse=True)
-    decoded_text = text
+    # A valid Base64 token can contain a shorter valid hex match. Decode the
+    # enclosing token once so replacements and offset shifts share one source.
+    candidates.sort(key=lambda c: (c.start, -c.end))
+    non_overlapping: list[EncodedCandidate] = []
     for candidate in candidates:
+        if not non_overlapping or candidate.start >= non_overlapping[-1].end:
+            non_overlapping.append(candidate)
+    candidates = non_overlapping
+    used_spans = {(candidate.start, candidate.end) for candidate in candidates}
+
+    # Build fully decoded text by replacing Hex and Base64 chunks first
+    decoded_text = text
+    for candidate in reversed(candidates):
         if candidate.decoded_text:
             decoded_text = decoded_text[: candidate.start] + candidate.decoded_text + decoded_text[candidate.end :]
 

--- a/tests/unit/test_structured_pii_masking.py
+++ b/tests/unit/test_structured_pii_masking.py
@@ -1,0 +1,49 @@
+"""Provider-bound structured PII masking regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from guardrails.client import GuardrailsAsyncOpenAI, GuardrailsOpenAI
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("stream", [False, True])
+async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous: bool, stream: bool) -> None:
+    """Mask every occurrence while preserving ordinary text and image parts."""
+    config = {
+        "version": 1,
+        "pre_flight": {
+            "version": 1,
+            "guardrails": [{"name": "Contains PII", "config": {"entities": ["EMAIL_ADDRESS"], "block": False, "detect_encoded_pii": True}}],
+        },
+    }
+    encoded = base64.b64encode(b"jane@example.com").decode()
+    image = {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
+    messages: Any = [{"role": "user", "content": [{"type": "text", "text": f"First: {encoded}; second: {encoded}. End."}, image]}]
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))])
+    if asynchronous:
+        client = GuardrailsAsyncOpenAI(config=config, api_key="test-key")
+        provider = AsyncMock(return_value=response)
+        client._resource_client.chat = SimpleNamespace(completions=SimpleNamespace(create=provider))
+        await client.chat.completions.create(messages=messages, model="test-model", stream=stream)
+    else:
+        sync_client = GuardrailsOpenAI(config=config, api_key="test-key")
+        provider = Mock(return_value=response)
+        sync_client._resource_client.chat = SimpleNamespace(completions=SimpleNamespace(create=provider))
+        await asyncio.to_thread(lambda: sync_client.chat.completions.create(messages=messages, model="test-model", stream=stream))
+
+    provider.assert_called_once()
+    forwarded = provider.call_args.kwargs["messages"]
+    assert forwarded[0]["content"] == [
+        {"type": "text", "text": "First: <EMAIL_ADDRESS_ENCODED>; second: <EMAIL_ADDRESS_ENCODED>. End."},
+        image,
+    ]
+    assert messages[0]["content"][0]["text"] == f"First: {encoded}; second: {encoded}. End."

--- a/tests/unit/test_structured_pii_masking.py
+++ b/tests/unit/test_structured_pii_masking.py
@@ -26,8 +26,9 @@ async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous:
         },
     }
     encoded = base64.b64encode(b"jane@example.com").decode()
+    note = base64.b64encode(b"example document").decode()
     image = {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
-    messages: Any = [{"role": "user", "content": [{"type": "text", "text": f"First: {encoded}; second: {encoded}. End."}, image]}]
+    messages: Any = [{"role": "user", "content": [{"type": "text", "text": f"Note: {note}; first: {encoded}; second: {encoded}. End."}, image]}]
     response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))])
     if asynchronous:
         client = GuardrailsAsyncOpenAI(config=config, api_key="test-key")
@@ -43,7 +44,7 @@ async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous:
     provider.assert_called_once()
     forwarded = provider.call_args.kwargs["messages"]
     assert forwarded[0]["content"] == [
-        {"type": "text", "text": "First: <EMAIL_ADDRESS_ENCODED>; second: <EMAIL_ADDRESS_ENCODED>. End."},
+        {"type": "text", "text": f"Note: {note}; first: <EMAIL_ADDRESS_ENCODED>; second: <EMAIL_ADDRESS_ENCODED>. End."},
         image,
     ]
-    assert messages[0]["content"][0]["text"] == f"First: {encoded}; second: {encoded}. End."
+    assert messages[0]["content"][0]["text"] == f"Note: {note}; first: {encoded}; second: {encoded}. End."

--- a/tests/unit/test_structured_pii_masking.py
+++ b/tests/unit/test_structured_pii_masking.py
@@ -17,8 +17,16 @@ from guardrails.client import GuardrailsAsyncOpenAI, GuardrailsOpenAI
 @pytest.mark.asyncio
 @pytest.mark.parametrize("asynchronous", [False, True])
 @pytest.mark.parametrize("stream", [False, True])
-@pytest.mark.parametrize("prefix", ["", (base64.b64encode(b"Snowman: %E2").decode() + "%98%83; ") * 10])
-async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous: bool, stream: bool, prefix: str) -> None:
+@pytest.mark.parametrize(
+    ("prefix", "payload"),
+    [
+        ("", b"jane@example.com"),
+        ((base64.b64encode(b"Snowman: %E2").decode() + "%98%83; ") * 10, b"jane@example.com"),
+        ("", b"\xeb\xae\xba" * 8 + b"\xeb\xaf\xbf john@example.com"),
+    ],
+    ids=["plain", "split-utf8", "overlapping-encodings"],
+)
+async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous: bool, stream: bool, prefix: str, payload: bytes) -> None:
     """Mask every occurrence while preserving ordinary text and image parts."""
     config = {
         "version": 1,
@@ -27,7 +35,7 @@ async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous:
             "guardrails": [{"name": "Contains PII", "config": {"entities": ["EMAIL_ADDRESS"], "block": False, "detect_encoded_pii": True}}],
         },
     }
-    encoded = base64.b64encode(b"jane@example.com").decode()
+    encoded = base64.b64encode(payload).decode()
     note = base64.b64encode(b"example document").decode()
     image = {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
     messages: Any = [

--- a/tests/unit/test_structured_pii_masking.py
+++ b/tests/unit/test_structured_pii_masking.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import urllib.parse
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -48,3 +49,49 @@ async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous:
         image,
     ]
     assert messages[0]["content"][0]["text"] == f"Note: {note}; first: {encoded}; second: {encoded}. End."
+
+
+@pytest.mark.parametrize("count", [100, 200, 400])
+def test_percent_escape_decoding_work_is_bounded(count: int) -> None:
+    """Preflight processes short URL escapes without repeatedly decoding prefixes."""
+    config = {
+        "version": 1,
+        "pre_flight": {
+            "version": 1,
+            "guardrails": [{"name": "Contains PII", "config": {"entities": ["EMAIL_ADDRESS"], "block": False, "detect_encoded_pii": True}}],
+        },
+    }
+    text = "%61 " * count
+    messages: Any = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+    client = GuardrailsOpenAI(config=config, api_key="test-key")
+    provider = Mock(return_value=SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))]))
+    client._resource_client.chat = SimpleNamespace(completions=SimpleNamespace(create=provider))
+
+    # Count actual input processed by the decoder, avoiding timing-dependent
+    # assertions and including every invocation made by public preflight.
+    with patch("guardrails.checks.text.pii.urllib.parse.unquote", wraps=urllib.parse.unquote) as decode:
+        client.chat.completions.create(messages=messages, model="test-model")
+
+    assert sum(len(call.args[0]) for call in decode.call_args_list) <= 4 * len(text)
+    provider.assert_called_once()
+    assert provider.call_args.kwargs["messages"] == messages
+
+
+def test_mixed_encoded_spans_preserve_unicode_and_unrelated_content() -> None:
+    """Decoded offsets remain correct across Unicode, hex, Base64 and partial URLs."""
+    from guardrails.checks.text.pii import _build_decoded_text
+
+    note = base64.b64encode(b"example document").decode()
+    email = b"jane@example.com".hex()
+    nested = base64.b64encode(b"joe%40example.com").decode()
+    text = f"Snowman: %E2%98%83; {note}; {email}; {nested}; jane%40example.com."
+    decoded, candidates = _build_decoded_text(text)
+
+    assert decoded == "Snowman: ☃; example document; jane@example.com; joe@example.com; jane@example.com."
+    assert [decoded[c.decoded_start : c.decoded_end] for c in candidates] == [
+        "☃",
+        "example document",
+        "jane@example.com",
+        "joe@example.com",
+        "@",
+    ]

--- a/tests/unit/test_structured_pii_masking.py
+++ b/tests/unit/test_structured_pii_masking.py
@@ -17,7 +17,8 @@ from guardrails.client import GuardrailsAsyncOpenAI, GuardrailsOpenAI
 @pytest.mark.asyncio
 @pytest.mark.parametrize("asynchronous", [False, True])
 @pytest.mark.parametrize("stream", [False, True])
-async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous: bool, stream: bool) -> None:
+@pytest.mark.parametrize("prefix", ["", (base64.b64encode(b"Snowman: %E2").decode() + "%98%83; ") * 10])
+async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous: bool, stream: bool, prefix: str) -> None:
     """Mask every occurrence while preserving ordinary text and image parts."""
     config = {
         "version": 1,
@@ -29,7 +30,9 @@ async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous:
     encoded = base64.b64encode(b"jane@example.com").decode()
     note = base64.b64encode(b"example document").decode()
     image = {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
-    messages: Any = [{"role": "user", "content": [{"type": "text", "text": f"Note: {note}; first: {encoded}; second: {encoded}. End."}, image]}]
+    messages: Any = [
+        {"role": "user", "content": [{"type": "text", "text": f"{prefix}Note: {note}; first: {encoded}; second: {encoded}. End."}, image]}
+    ]
     response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))])
     if asynchronous:
         client = GuardrailsAsyncOpenAI(config=config, api_key="test-key")
@@ -45,10 +48,10 @@ async def test_repeated_encoded_pii_is_masked_before_provider_call(asynchronous:
     provider.assert_called_once()
     forwarded = provider.call_args.kwargs["messages"]
     assert forwarded[0]["content"] == [
-        {"type": "text", "text": f"Note: {note}; first: <EMAIL_ADDRESS_ENCODED>; second: <EMAIL_ADDRESS_ENCODED>. End."},
+        {"type": "text", "text": f"{prefix}Note: {note}; first: <EMAIL_ADDRESS_ENCODED>; second: <EMAIL_ADDRESS_ENCODED>. End."},
         image,
     ]
-    assert messages[0]["content"][0]["text"] == f"Note: {note}; first: {encoded}; second: {encoded}. End."
+    assert messages[0]["content"][0]["text"] == f"{prefix}Note: {note}; first: {encoded}; second: {encoded}. End."
 
 
 @pytest.mark.parametrize("count", [100, 200, 400])
@@ -95,3 +98,11 @@ def test_mixed_encoded_spans_preserve_unicode_and_unrelated_content() -> None:
         "joe@example.com",
         "@",
     ]
+
+
+@pytest.mark.parametrize("text", ["☃ %E2%98%83 end", "%F0%9F%92%A9", "%E2%98text", "%FF%C3%A9", "%4x%41%", "%ED%A0%80"])
+def test_url_offsets_match_standard_library_prefix_decoding(text: str) -> None:
+    """Offsets retain unquote semantics even inside percent and UTF-8 sequences."""
+    from guardrails.checks.text.pii import _url_decoded_offsets
+
+    assert _url_decoded_offsets(text) == [len(urllib.parse.unquote(text[:end])) for end in range(len(text) + 1)]


### PR DESCRIPTION
This pull request fixes repeated encoded PII masking in structured messages by reusing the existing detection and masking pipeline. Detections are associated with actual decoded positions, and overlapping hex/Base64 candidates are selected before transformation so enclosing PII tokens are masked completely. A linear offset map preserves whole-stream percent and UTF-8 decoding across encoding boundaries; unrelated content and existing public APIs, configuration, formats and markers are preserved.

Validation: 103 focused tests and all 1,430 repository tests pass; formatting, lint, mypy and pyright pass. Provider-bound regressions cover repeated masking, unrelated-content preservation, split UTF-8 and overlapping encodings across sync/async and streaming/non-streaming calls. Two consecutive independent review pairs are clean, including security review.