### PR TITLE
fix: preserve conversation evaluation provider configuration

### DIFF
--- a/src/guardrails/evals/core/async_engine.py
+++ b/src/guardrails/evals/core/async_engine.py
@@ -362,8 +362,10 @@ class AsyncRunEngine(RunEngine):
                         # Create a temporary GuardrailsAsyncOpenAI client for conversation-aware guardrails
                         temp_client = GuardrailsAsyncOpenAI(
                             config=minimal_config,
-                            api_key=getattr(context.guardrail_llm, "api_key", None) or "fake-key-for-eval",
+                            api_key="fake-key-for-eval",
                         )
+                        # Keep the selected provider, authentication, and transport for analysis.
+                        temp_client.context = context
 
                         # Normalize conversation history using the client's normalization
                         normalized_conversation = temp_client._normalize_conversation(conversation_history)

--- a/tests/unit/evals/test_conversation_provider.py
+++ b/tests/unit/evals/test_conversation_provider.py
@@ -1,0 +1,57 @@
+"""Conversation evaluation preserves the configured analysis client."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+from guardrails import instantiate_guardrails
+from guardrails.checks.text import llm_base
+from guardrails.evals.core.async_engine import AsyncRunEngine
+from guardrails.evals.core.types import Context, Sample
+from guardrails.runtime import ConfigBundle
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("azure", [False, True])
+@pytest.mark.parametrize("multi_turn", [False, True])
+async def test_conversation_evaluation_preserves_provider(monkeypatch: pytest.MonkeyPatch, azure: bool, multi_turn: bool) -> None:
+    """The actual LLM check receives the selected client on every evaluated turn."""
+    client: AsyncOpenAI
+    if azure:
+        client = AsyncAzureOpenAI(
+            azure_endpoint="https://evaluation.azure.invalid",
+            api_version="2025-01-01-preview",
+            azure_ad_token="test-token",
+        )
+    else:
+        client = AsyncOpenAI(api_key="test-key", base_url="https://evaluation.invalid/v1", max_retries=0)
+
+    completion = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content='{"flagged": false, "confidence": 0.1, "reason": "benign"}'))],
+        usage=None,
+    )
+    request = AsyncMock(return_value=completion)
+    monkeypatch.setattr(llm_base, "_request_chat_completion", request)
+    guardrails = instantiate_guardrails(
+        ConfigBundle.model_validate(
+            {
+                "version": 1,
+                "guardrails": [{"name": "Jailbreak", "config": {"model": "test-model"}}],
+            }
+        )
+    )
+    engine = AsyncRunEngine(guardrails, multi_turn=multi_turn)
+    sample = Sample(
+        id="conversation",
+        data='[{"role": "user", "content": "Hello"}, {"role": "user", "content": "Good morning"}]',
+        expected_triggers={"Jailbreak": False},
+    )
+    results = await engine.run(Context(guardrail_llm=client), [sample], batch_size=1)
+    assert request.await_count == (2 if multi_turn else 1)
+    for call in request.await_args_list:
+        assert call.kwargs["client"] is client
+    assert "Good morning" in str(request.await_args_list[-1].kwargs["messages"])
+    assert results[0].triggered == {"Jailbreak": False}
+    assert "error" not in results[0].details


### PR DESCRIPTION
This pull request fixes conversation-aware evaluation discarding the configured analysis provider. It reuses the evaluation context's client for single-pass and multi-turn checks, preserving its endpoint, authentication, and transport settings instead of copying its credential into a default OpenAI client.

Public signatures, conversation normalization, tripwire suppression, fallback behavior, and result formats remain unchanged. Regression tests exercise the built-in LLM check with OpenAI-compatible and Azure configurations in both evaluation modes.

Validation: formatting, Ruff, mypy, pyright, and all 1,344 tests pass after rebasing onto current main. Independent correctness/security and architecture/ownership reviews completed with two consecutive clean rounds on the final diff.