### PR TITLE
fix: honor strict errors in prompt injection detection

### DIFF
--- a/src/guardrails/checks/text/prompt_injection_detection.py
+++ b/src/guardrails/checks/text/prompt_injection_detection.py
@@ -31,6 +31,7 @@ Examples:
 from __future__ import annotations
 
 import textwrap
+from dataclasses import replace
 from typing import Any, TypedDict
 
 from pydantic import Field
@@ -332,11 +333,12 @@ Previous context:
         return result
 
     except Exception as e:
-        return _create_skip_result(
+        result = _create_skip_result(
             f"Error during prompt injection detection check: {str(e)}",
             config.confidence_threshold,
             data=str(data),
         )
+        return replace(result, execution_failed=True, original_exception=e)
 
 
 def _slice_conversation_since_latest_user(

--- a/tests/unit/checks/test_prompt_injection_detection.py
+++ b/tests/unit/checks/test_prompt_injection_detection.py
@@ -9,8 +9,10 @@ if TYPE_CHECKING:
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from openai import AsyncOpenAI
 
 from guardrails.checks.text import prompt_injection_detection as pid_module
 from guardrails.checks.text.llm_base import LLMConfig, LLMOutput
@@ -20,6 +22,7 @@ from guardrails.checks.text.prompt_injection_detection import (
     _should_analyze,
     prompt_injection_detection,
 )
+from guardrails.runtime import ConfigBundle, GuardrailConfig, instantiate_guardrails, run_guardrails
 from guardrails.types import TokenUsage
 
 
@@ -186,12 +189,14 @@ async def test_prompt_injection_detection_skips_without_history(monkeypatch: pyt
 
 @pytest.mark.asyncio
 async def test_prompt_injection_detection_handles_analysis_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Exceptions during analysis should return a skip result."""
+    """Analysis errors remain non-tripwire results and retain the original failure."""
     history = _make_history({"type": "function_call", "tool_name": "get_weather", "arguments": "{}"})
     context = _FakeContext(history)
 
+    error = RuntimeError("LLM failed")
+
     async def failing_llm(*_args: Any, **_kwargs: Any) -> PromptInjectionDetectionOutput:
-        raise RuntimeError("LLM failed")
+        raise error
 
     monkeypatch.setattr(pid_module, "_call_prompt_injection_detection_llm", failing_llm)
 
@@ -199,7 +204,9 @@ async def test_prompt_injection_detection_handles_analysis_error(monkeypatch: py
     result = await prompt_injection_detection(cast("GuardrailLLMContextProto", context), data="{}", config=config)
 
     assert result.tripwire_triggered is False  # noqa: S101
-    assert "Error during prompt injection detection check" in result.info["observation"]  # noqa: S101
+    assert "Error during prompt injection detection check" in result.info["observation"]
+    assert result.execution_failed is True
+    assert result.original_exception is error
 
 
 @pytest.mark.asyncio
@@ -621,3 +628,49 @@ async def test_prompt_injection_detection_excludes_reasoning_when_disabled(
     assert "evidence" not in result.info  # noqa: S101
     assert result.info["flagged"] is False  # noqa: S101
     assert result.info["confidence"] == 0.1  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strict", [False, True])
+@pytest.mark.parametrize("failure", [RuntimeError("Provider unavailable"), ValueError("Invalid analysis response")])
+async def test_analysis_failure_respects_runtime_error_policy(strict: bool, failure: Exception) -> None:
+    """Actual check failures obey strict mode independently of tripwire suppression."""
+    client = Mock(spec=AsyncOpenAI)
+    parse = AsyncMock(side_effect=failure)
+    client.responses = SimpleNamespace(parse=parse)
+    context = SimpleNamespace(
+        guardrail_llm=client,
+        get_conversation_history=lambda: _make_history({"type": "function_call", "name": "get_weather", "arguments": "{}"}),
+    )
+    guardrails = instantiate_guardrails(ConfigBundle(guardrails=[GuardrailConfig(name="Prompt Injection Detection", config={"model": "gpt-test"})]))
+    if strict:
+        with pytest.raises(type(failure)) as caught:
+            await run_guardrails(context, "{}", "text/plain", guardrails, raise_guardrail_errors=True, suppress_tripwire=True)
+        assert caught.value is failure
+    else:
+        results = await run_guardrails(context, "{}", "text/plain", guardrails)
+        assert len(results) == 1
+        assert results[0].tripwire_triggered is False
+        assert results[0].execution_failed is True
+        assert results[0].original_exception is failure
+    parse.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "history",
+    [[], [{"type": "function_call", "name": "get_weather", "arguments": "{}"}], [{"role": "user", "content": "Weather?"}]],
+)
+async def test_intentional_skip_remains_safe_in_strict_mode(history: list[Any]) -> None:
+    """Inapplicable conversations remain no-ops even when execution errors are strict."""
+    client = Mock(spec=AsyncOpenAI)
+    parse = AsyncMock()
+    client.responses = SimpleNamespace(parse=parse)
+    context = SimpleNamespace(guardrail_llm=client, get_conversation_history=lambda: history)
+    guardrails = instantiate_guardrails(ConfigBundle(guardrails=[GuardrailConfig(name="Prompt Injection Detection", config={"model": "gpt-test"})]))
+    results = await run_guardrails(context, "{}", "text/plain", guardrails, raise_guardrail_errors=True)
+    assert len(results) == 1
+    assert results[0].tripwire_triggered is False
+    assert results[0].execution_failed is False
+    assert results[0].original_exception is None
+    parse.assert_not_awaited()

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -8,8 +8,10 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from openai import AsyncOpenAI
 
 from guardrails.types import GuardrailResult
 
@@ -1271,3 +1273,36 @@ async def test_tool_guardrail_uses_correct_stage_name_output(monkeypatch: pytest
 
     # Should use "tool_output", not a guardrail-specific name
     assert captured_stage_name == "tool_output"  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strict", [False, True])
+async def test_prompt_injection_tool_input_analysis_failure(strict: bool) -> None:
+    """The actual prompt injection check blocks analysis failures only in strict mode."""
+    from guardrails.runtime import ConfigBundle, GuardrailConfig, instantiate_guardrails
+
+    guardrail = instantiate_guardrails(ConfigBundle(guardrails=[GuardrailConfig(name="Prompt Injection Detection", config={"model": "gpt-test"})]))[0]
+    session_token = agents._agent_session.set(None)
+    conversation_token = agents._agent_conversation.set(({"role": "user", "content": "Weather in Paris?"},))
+    try:
+        client = Mock(spec=AsyncOpenAI)
+        parse = AsyncMock(side_effect=RuntimeError("Analysis unavailable"))
+        client.responses = SimpleNamespace(parse=parse)
+        tool_fn = agents._create_tool_guardrail(
+            guardrail=guardrail,
+            guardrail_type="input",
+            context=SimpleNamespace(guardrail_llm=client),
+            raise_guardrail_errors=strict,
+            block_on_violations=False,
+        )
+        data = agents_module.ToolInputGuardrailData(context=ToolContext(tool_name="weather", tool_arguments={"city": "Paris"}))
+        result = await cast(Callable[..., Awaitable[Any]], tool_fn)(data)
+        assert result.tripwire_triggered is strict
+        if strict:
+            assert result.message == "raise"
+        else:
+            assert "Error during prompt injection detection check" in result.output_info["observation"]
+        parse.assert_awaited_once()
+    finally:
+        agents._agent_session.reset(session_token)
+        agents._agent_conversation.reset(conversation_token)


### PR DESCRIPTION
This pull request fixes Prompt Injection Detection treating analysis failures as successful skips when `raise_guardrail_errors=True`. It marks caught exceptions using the existing execution-failure result fields, allowing the runtime and Agents tool guardrails to enforce strict error handling while preserving default fail-open behavior, result metadata, and intentional applicability skips.

Validation: 1,349 tests passed; Ruff formatting/lint, mypy, and pyright passed. Hermetic regressions cover strict and default runtime handling, intentional skips, and the Agents tool-input adapter.