### PR TITLE
fix: use GITHUB_TOKEN for release automation

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,21 +1,21 @@
 # Releasing
 
-Releases use release-please, following the GitHub App setup in `openai/openai-python`.
+Releases use release-please with the repository's `GITHUB_TOKEN`. No SDK GitHub
+App installation, client ID, or private key is required.
 
 ## One-time setup
 
-Before enabling the workflow, install the OpenAI SDKs GitHub App on this repository
-with Contents, Issues, and Pull requests write permissions. Make
-`OPENAI_SDKS_APP_CLIENT_ID` available as an Actions variable and
-`OPENAI_SDKS_APP_PRIVATE_KEY` as an Actions secret to the `release` environment.
-Restrict that environment to `main`. The App token lets release PRs run CI and
-published GitHub Releases trigger the separate publishing workflow; substituting
-`GITHUB_TOKEN` prevents those downstream workflow runs.
+Allow GitHub Actions to create pull requests in this repository's Actions
+settings. The release job grants its token Contents, Issues, Pull requests, and
+Actions write permissions; other jobs keep their own scoped permissions.
+Require SDK-team approval for the `release` environment and restrict it to the
+exact `main` branch.
 
 Keep the existing PyPI trusted publisher for `openai/openai-guardrails-python`,
-workflow `publish.yml`, environment `pypi`. This migration does not rename that
-OIDC identity. Check the environment's approval rules and tag deployment rules
-before releasing; these settings live outside the repository.
+workflow `publish.yml`, environment `pypi`. Restrict `pypi` deployments to `v*`
+tags and require SDK-team approval. Protect release tags against unauthorized
+creation, updates, and deletion while allowing the release workflow to create
+new tags. These controls live in GitHub settings, not workflow YAML.
 
 ## Routine releases
 
@@ -23,22 +23,37 @@ before releasing; these settings live outside the repository.
    produces a patch bump, `feat:` a minor bump, and breaking changes a minor bump
    while the package is pre-1.0. Release notes use the sections in
    `release-please-config.json`.
-2. On pushes to `main`, release-please opens or updates a release PR containing
-   the version in `pyproject.toml`, `CHANGELOG.md`, and
-   `.release-please-manifest.json`. The manifest starts at the existing `v0.3.2`
-   release. The package reads its runtime version from installed metadata, so no
-   source version constant needs updating.
-3. Review the proposed version and changelog, check CI, and run the repository's
-   final release review before merging the release PR. Merging authorizes
-   release-please to create the `vX.Y.Z` tag and publish a GitHub Release.
-4. That release event runs `publish.yml` against the release tag. It builds the
-   wheel and sdist in a job without OIDC permission, then transfers the artifacts
-   to an upload-only job in the `pypi` environment. The PyPI action uses OIDC
-   trusted publishing and explicitly enables PEP 740 attestations.
-5. Confirm the publishing run succeeded and inspect the files and attestations
+2. Approve the `release` environment run after a push to `main`. Release-please
+   opens or updates a release PR containing the version in `pyproject.toml`,
+   `CHANGELOG.md`, and `.release-please-manifest.json`. The manifest starts at
+   the existing `v0.3.2` release. The package reads its runtime version from
+   installed metadata, so no source version constant needs updating.
+3. For a token-created or updated PR, approve its pending workflow runs using
+   **Approve workflows to run** in the PR merge box. Review the proposed version
+   and changelog, wait for required CI, and run the repository's final release
+   review before merging the release PR.
+4. Approve the ensuing `release` environment run. Release-please creates the
+   `vX.Y.Z` tag and publishes a GitHub Release, then explicitly dispatches
+   `publish.yml` at that tag. `GITHUB_TOKEN`-created releases do not trigger
+   release-event workflows; `workflow_dispatch` provides the handoff. Releases
+   published directly by a maintainer still use the `release: published` event.
+5. The publishing workflow requires a published GitHub Release and verifies
+   that the checked-out tag commit is an ancestor of `main` before installing
+   dependencies. It builds the wheel and sdist without OIDC permission, then
+   transfers the artifacts to an upload-only job in the `pypi` environment.
+   Approve that deployment after checking the release tag and build. The PyPI
+   action uses OIDC trusted publishing and explicitly enables PEP 740 attestations.
+6. Confirm the publishing run succeeded and inspect the files and attestations
    on PyPI. Configuration alone does not prove a particular upload succeeded.
 
-If publishing fails, rerun the failed job from the original release workflow run
+## Recovery
+
+If release creation succeeds but dispatch fails, manually run **Publish to
+PyPI** from the Actions UI with the published release tag selected. Select a
+`v*` tag containing the dispatch-enabled workflow; branch runs are skipped.
+Rerunning release-please alone may not dispatch an already-created release.
+
+If publishing fails, rerun the failed job from the original publishing run
 while its artifacts remain available (one day), or rerun the whole original run
 to rebuild from its release tag. Do not create a new version solely to retry a
 failed upload. If an upload partially succeeded, inspect PyPI before retrying:

--- a/.github/workflows/create-releases.yml
+++ b/.github/workflows/create-releases.yml
@@ -15,21 +15,31 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.repository == 'openai/openai-guardrails-python'
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      actions: write
     steps:
-      - name: Create release app token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.OPENAI_SDKS_APP_CLIENT_ID }}
-          private-key: ${{ secrets.OPENAI_SDKS_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
-
       - name: Create release PR or GitHub Release
+        id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # GITHUB_TOKEN-created releases do not trigger release-event workflows.
+      - name: Start PyPI publishing
+        if: steps.release.outputs.release_created == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              ...context.repo,
+              workflow_id: 'publish.yml',
+              ref: `refs/tags/${process.env.RELEASE_TAG}`,
+            });

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish to PyPI
 
 on:
+  workflow_dispatch:
   release:
     types:
       - published
@@ -9,16 +10,30 @@ permissions: {}
 
 jobs:
   build:
-    if: github.repository == 'openai/openai-guardrails-python'
+    if: github.repository == 'openai/openai-guardrails-python' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     # Package build code must not have access to publishing credentials.
     permissions:
       contents: read
     steps:
+      - name: Verify published release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              ...context.repo,
+              tag: context.ref.slice('refs/tags/'.length),
+            });
+            if (release.draft || !release.published_at) {
+              throw new Error('Publishing requires a published GitHub Release.');
+            }
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+      - name: Verify release is from main
+        run: git merge-base --is-ancestor HEAD refs/remotes/origin/main
       - name: Setup uv
         uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5
         with:


### PR DESCRIPTION
This pull request updates release-please to use GITHUB_TOKEN and explicitly dispatches PyPI publishing at the created release tag. Publishing requires a published GitHub Release from main and preserves the existing publish.yml/pypi trusted-publisher identity, isolated build/upload jobs, and PEP 740 attestations.

The release guide documents required GitHub settings, workflow approvals, and recovery when release creation succeeds but publishing dispatch fails.

Validation: two consecutive independent adversarial review rounds found no blockers. Workflow lint and focused release-flow probes pass; formatting, Ruff, Mypy, Pyright, all 1,369 tests, and the documentation build pass.