### PR TITLE
fix: enforce component restrictions for IP URL allow-list entries

### DIFF
--- a/src/guardrails/checks/text/urls.py
+++ b/src/guardrails/checks/text/urls.py
@@ -1942,45 +1942,34 @@ def _is_url_allowed(
         except (AddressValueError, ValueError):
             allowed_ip = None
 
-        if allowed_ip is not None:
-            if url_ip is None:
-                continue
-            # Scheme matching for IPs: if both allow list and URL have explicit schemes, they must match
-            if has_explicit_scheme and url_had_explicit_scheme and allowed_scheme and allowed_scheme != scheme_lower:
-                continue
-            # Port matching: enforce if allow list has explicit port
-            if allowed_port_explicit is not None and allowed_port != url_port:
-                continue
-            if allowed_ip == url_ip:
-                return True
-
-            network_spec = allowed_host
-            if parsed_allowed.path not in ("", "/"):
-                network_spec = f"{network_spec}{parsed_allowed.path}"
-            try:
-                if network_spec and "/" in network_spec and url_ip in ip_network(network_spec, strict=False):
-                    return True
-            except (AddressValueError, ValueError):
-                # Path segment might not represent a CIDR mask; ignore.
-                pass
+        # Scheme and port restrictions apply to both host and network entries.
+        if has_explicit_scheme and url_had_explicit_scheme and allowed_scheme and allowed_scheme != scheme_lower:
             continue
-
-        if not allowed_host:
-            continue
-
-        allowed_domain = allowed_host.removeprefix("www.")
-
-        # Port matching: enforce if allow list has explicit port
         if allowed_port_explicit is not None and allowed_port != url_port:
             continue
 
-        host_matches = url_domain == allowed_domain or (allow_subdomains and url_domain.endswith(f".{allowed_domain}"))
-        if not host_matches:
-            continue
-
-        # Scheme matching: if both allow list and URL have explicit schemes, they must match
-        if has_explicit_scheme and url_had_explicit_scheme and allowed_scheme and allowed_scheme != scheme_lower:
-            continue
+        if allowed_ip is not None:
+            if url_ip is None:
+                continue
+            if allowed_path not in ("", "/"):
+                try:
+                    allowed_network = ip_network(f"{allowed_host}{allowed_path}", strict=False)
+                except (AddressValueError, ValueError):
+                    # An ordinary URL path is not a CIDR mask.
+                    pass
+                else:
+                    if url_ip in allowed_network:
+                        return True
+                    continue
+            if allowed_ip != url_ip:
+                continue
+        else:
+            if not allowed_host:
+                continue
+            allowed_domain = allowed_host.removeprefix("www.")
+            host_matches = url_domain == allowed_domain or (allow_subdomains and url_domain.endswith(f".{allowed_domain}"))
+            if not host_matches:
+                continue
 
         # Path matching with segment boundary respect
         if allowed_path not in ("", "/"):

--- a/tests/unit/checks/test_urls.py
+++ b/tests/unit/checks/test_urls.py
@@ -3656,3 +3656,52 @@ async def test_urls_guardrail_blocks_subdomains_and_paths_correctly() -> None:
     assert len(result.info["blocked"]) == 2  # noqa: S101
     assert "help-suntropy.es" in result.info["blocked"]  # noqa: S101
     assert "help.suntropy.es" in result.info["blocked"]  # noqa: S101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("host", ["192.0.2.10", "[2001:db8::10]"])
+@pytest.mark.parametrize(
+    ("suffix", "blocked"),
+    [
+        ("/docs?view=full#intro", False),
+        ("/docs/chapter?view=full#intro", False),
+        ("/other?view=full#intro", True),
+        ("/docs2?view=full#intro", True),
+        ("/docs?view=short#intro", True),
+        ("/docs?view=full#other", True),
+    ],
+)
+async def test_ip_url_component_restrictions(host: str, suffix: str, blocked: bool) -> None:
+    """Full IP URLs enforce the configured path, query, and fragment."""
+    candidate = f"https://{host}{suffix}"
+    config = URLConfig(url_allow_list=[f"https://{host}/docs?view=full#intro"])
+
+    result = await urls(None, candidate, config)
+
+    assert result.info["detected"] == [candidate]
+    assert result.tripwire_triggered is blocked
+    assert result.info["allowed"] == ([] if blocked else [candidate])
+    assert result.info["blocked"] == ([candidate] if blocked else [])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("entry", "host"),
+    [
+        ("192.0.2.10", "192.0.2.10"),
+        ("[2001:db8::10]", "[2001:db8::10]"),
+        ("192.0.2.0/24", "192.0.2.0"),
+        ("192.0.2.0/24", "192.0.2.10"),
+        ("[2001:db8::]/64", "[2001:db8::10]"),
+        ("https://192.0.2.0/24", "192.0.2.10"),
+    ],
+)
+async def test_ip_and_cidr_entries_keep_unrestricted_components(entry: str, host: str) -> None:
+    """Bare IP and CIDR entries continue to allow arbitrary URL components."""
+    candidate = f"https://{host}/docs?view=full#intro"
+
+    result = await urls(None, candidate, URLConfig(url_allow_list=[entry]))
+
+    assert result.info["detected"] == [candidate]
+    assert result.tripwire_triggered is False
+    assert result.info["allowed"] == [candidate]


### PR DESCRIPTION
This pull request fixes full IP-host URL allow-list entries skipping their configured path, query, and fragment restrictions. Ordinary IPv4 and IPv6 URLs now reuse the existing component checks after matching the host; bare IP and valid CIDR entries retain their broad matching semantics, including scheme-qualified networks. Public signatures, configuration fields, explicit scheme and port checks, and domain matching remain unchanged.

Validation: all 1,408 tests pass, including 18 new public-boundary cases. Formatting, Ruff, mypy, and pyright pass; two fresh independent review rounds on the rebased commit found no blocking issues.