### PR TITLE
test: cover public SDK and evaluation contracts

### DIFF
--- a/tests/integration/real_sdk/contract_cases.py
+++ b/tests/integration/real_sdk/contract_cases.py
@@ -1,0 +1,382 @@
+"""Public contracts using real SDK models and in-memory HTTP exchanges.
+
+Invoked by test_real_sdk_contract.py in isolation from the parent conftest.
+The filename deliberately avoids default collection in the stubbed interpreter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import socket
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import openai
+import pytest
+import pytest_asyncio
+from pydantic import BaseModel
+
+import guardrails
+from guardrails import GuardrailsResponse, GuardrailTripwireTriggered
+from guardrails.context import GuardrailsContext, clear_context, set_context
+
+# Match the HTTP implementation used by the installed SDK (httpx or httpx2).
+# Mocking its transport keeps SDK validation, routing and decoding intact.
+http = importlib.import_module(openai.DefaultHttpxClient.__mro__[1].__module__.split(".")[0])
+
+
+@pytest.fixture(autouse=True)
+def forbid_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def denied(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("Real SDK contract tests must not open network connections")
+
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    monkeypatch.setattr(socket.socket, "connect_ex", denied)
+    monkeypatch.setattr(socket, "create_connection", denied)
+
+
+def pipeline(stage: str = "output", keyword: str | None = None) -> dict[str, Any]:
+    checks = [] if keyword is None else [{"name": "Keyword Filter", "config": {"keywords": [keyword]}}]
+    return {"version": 1, stage: {"version": 1, "guardrails": checks}}
+
+
+def response_body(chat: bool, text: str = "hello") -> dict[str, Any]:
+    if chat:
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 1,
+            "model": "test-model",
+            "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": text}}],
+        }
+    return {
+        "id": "resp_test",
+        "object": "response",
+        "created_at": 1,
+        "model": "test-model",
+        "status": "completed",
+        "output": [
+            {
+                "id": "msg_test",
+                "type": "message",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{"type": "output_text", "text": text, "annotations": []}],
+            }
+        ],
+    }
+
+
+@pytest_asyncio.fixture
+async def client_case(request: pytest.FixtureRequest) -> AsyncIterator[tuple[Any, list[Any], bool, bool]]:
+    asynchronous, azure = request.param
+    requests: list[Any] = []
+
+    def handler(req: Any) -> Any:
+        requests.append(req)
+        if req.headers.get("x-contract-error") == "yes":
+            return http.Response(429, json={"error": {"message": "test rate limit", "type": "rate_limit_error"}})
+        body = json.loads(req.content) if req.content else {}
+        chat = "/chat/completions" in req.url.path
+        if body.get("stream"):
+            if chat:
+                event = {
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion.chunk",
+                    "created": 1,
+                    "model": "test-model",
+                    "choices": [{"index": 0, "delta": {"content": "hello"}, "finish_reason": None}],
+                }
+            else:
+                event = {
+                    "type": "response.output_text.delta",
+                    "item_id": "msg_test",
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": "hello",
+                    "sequence_number": 1,
+                }
+            return http.Response(
+                200, headers={"content-type": "text/event-stream"}, content=f"data: {json.dumps(event)}\n\ndata: [DONE]\n\n".encode()
+            )
+        text = '{"answer":"hello"}' if "text" in body else "hello"
+        return http.Response(200, json=response_body(chat, text))
+
+    transport = http.MockTransport(handler)
+    http_client = (http.AsyncClient if asynchronous else http.Client)(transport=transport, trust_env=False)
+    kwargs: dict[str, Any] = {"api_key": "test-key", "max_retries": 0, "http_client": http_client}
+    cls: Any
+    if azure:
+        kwargs.update(azure_endpoint="https://unit-test.openai.azure.com", api_version="2025-04-01-preview")
+        cls = guardrails.GuardrailsAsyncAzureOpenAI if asynchronous else guardrails.GuardrailsAzureOpenAI
+    else:
+        kwargs["base_url"] = "https://api.openai.com/v1"
+        cls = guardrails.GuardrailsAsyncOpenAI if asynchronous else guardrails.GuardrailsOpenAI
+    # Use an explicit context to keep every possible provider call on the mock.
+    sdk_cls = (openai.AsyncAzureOpenAI if asynchronous else openai.AzureOpenAI) if azure else (openai.AsyncOpenAI if asynchronous else openai.OpenAI)
+    provider: Any = sdk_cls(**kwargs)
+    set_context(GuardrailsContext(provider))
+    clients: list[Any] = []
+
+    def make(config: dict[str, Any] | None = None) -> Any:
+        client = cls(config=config or pipeline(), **kwargs)
+        clients.append(client)
+        return client
+
+    try:
+        yield make, requests, asynchronous, azure
+    finally:
+        clear_context()
+        for client in clients:
+            if asynchronous:
+                await client.close()
+                await client._resource_client.close()
+            else:
+                client.close()
+                client._resource_client.close()
+        if asynchronous:
+            await provider.close()
+        else:
+            provider.close()
+
+
+CLIENTS = [(False, False), (True, False), (False, True), (True, True)]
+
+
+async def call(function: Any, asynchronous: bool, *args: Any, **kwargs: Any) -> Any:
+    # Sync Guardrails calls own their event loop; exercise them off the pytest loop.
+    if asynchronous:
+        return await function(*args, **kwargs)
+    return await asyncio.to_thread(function, *args, **kwargs)
+
+
+async def invoke(client: Any, asynchronous: bool, api: str, **kwargs: Any) -> Any:
+    if api == "chat":
+        return await call(client.chat.completions.create, asynchronous, messages=[{"role": "user", "content": "hello"}], model="test-model", **kwargs)
+    return await call(client.responses.create, asynchronous, input="hello", model="test-model", **kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_case", CLIENTS, indirect=True)
+@pytest.mark.parametrize("api", ["chat", "responses"])
+@pytest.mark.parametrize("stream", [False, True])
+async def test_create_wire_contract(client_case: Any, api: str, stream: bool) -> None:
+    make, requests, asynchronous, azure = client_case
+    result = await invoke(make(), asynchronous, api, stream=stream, temperature=0.2, extra_headers={"x-contract": "yes"})
+    if stream:
+        chunks = [chunk async for chunk in result] if asynchronous else await asyncio.to_thread(list, result)
+        assert len(chunks) == 1
+        result = chunks[0]
+        assert (result.choices[0].delta.content if api == "chat" else result.delta) == "hello"
+    else:
+        assert (result.choices[0].message.content if api == "chat" else result.output_text) == "hello"
+    assert isinstance(result, GuardrailsResponse)
+    assert result.guardrail_results.all_results == []
+    assert len(requests) == 1
+    req = requests[0]
+    body = json.loads(req.content)
+    assert body["temperature"] == 0.2
+    assert body["stream"] is stream
+    assert "suppress_tripwire" not in body
+    assert req.headers["x-contract"] == "yes"
+    assert ("safety_identifier" in body) is not azure
+    if azure:
+        assert req.url.host == "unit-test.openai.azure.com"
+        assert req.url.params["api-version"] == "2025-04-01-preview"
+        assert req.headers["api-key"] == "test-key"
+        if api == "chat":
+            assert "/deployments/test-model/chat/completions" in req.url.path
+    else:
+        assert req.headers["authorization"] == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_case", CLIENTS, indirect=True)
+@pytest.mark.parametrize("api", ["chat", "responses"])
+@pytest.mark.parametrize("stage", ["pre_flight", "output"])
+async def test_actual_check_tripwire_and_suppression(client_case: Any, api: str, stage: str) -> None:
+    make, requests, asynchronous, _ = client_case
+    client = make(pipeline(stage, "hello"))
+    with pytest.raises(GuardrailTripwireTriggered):
+        await invoke(client, asynchronous, api)
+    assert len(requests) == (0 if stage == "pre_flight" else 1)
+    result = await invoke(client, asynchronous, api, suppress_tripwire=True)
+    assert result.guardrail_results.tripwires_triggered
+    assert len(result.guardrail_results.triggered_results) == 1
+    assert len(requests) == (1 if stage == "pre_flight" else 2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_case", CLIENTS, indirect=True)
+async def test_retrieve_validates_actual_response(client_case: Any) -> None:
+    make, requests, asynchronous, _ = client_case
+    result = await call(make(pipeline("output", "hello")).responses.retrieve, asynchronous, "resp_test", suppress_tripwire=True)
+    assert result.output_text == "hello"
+    assert result.guardrail_results.output[0].tripwire_triggered
+    assert requests[0].method == "GET"
+    assert requests[0].url.path.endswith("/responses/resp_test")
+
+
+class Answer(BaseModel):
+    """Structured response expected by a caller."""
+
+    answer: str
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_case", CLIENTS, indirect=True)
+async def test_parse_actual_response(client_case: Any) -> None:
+    make, requests, asynchronous, _ = client_case
+    result = await call(make().responses.parse, asynchronous, input=[{"role": "user", "content": "hello"}], model="test-model", text_format=Answer)
+    assert result.output_parsed == Answer(answer="hello")
+    body = json.loads(requests[0].content)
+    assert body["text"]["format"]["type"] == "json_schema"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "ConfiguredGuardrail",
+        "GuardrailAgent",
+        "GuardrailResult",
+        "GuardrailResults",
+        "GuardrailTripwireTriggered",
+        "GuardrailsAsyncOpenAI",
+        "GuardrailsOpenAI",
+        "GuardrailsAsyncAzureOpenAI",
+        "GuardrailsAzureOpenAI",
+        "GuardrailsResponse",
+        "check_plain_text",
+        "checks",
+        "JsonString",
+        "ConfigSource",
+        "run_guardrails",
+        "GuardrailSpecMetadata",
+        "instantiate_guardrails",
+        "load_config_bundle",
+        "load_pipeline_bundles",
+        "default_spec_registry",
+        "resources",
+        "total_guardrail_token_usage",
+    ],
+)
+def test_released_public_exports(name: str) -> None:
+    assert name in guardrails.__all__
+    assert getattr(guardrails, name) is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source_kind", ["dict", "path", "json", "model"])
+async def test_configuration_to_execution(tmp_path: Path, source_kind: str) -> None:
+    bundle = pipeline("output", "hello")["output"]
+    source: Any = bundle
+    if source_kind == "path":
+        source = tmp_path / "bundle.json"
+        source.write_text(json.dumps(bundle))
+    elif source_kind == "json":
+        source = guardrails.JsonString(json.dumps(bundle))
+    elif source_kind == "model":
+        source = guardrails.load_config_bundle(bundle)
+    configured = guardrails.instantiate_guardrails(guardrails.load_config_bundle(source))
+    with pytest.raises(GuardrailTripwireTriggered):
+        await guardrails.run_guardrails({}, "hello", "text/plain", configured)
+    results = await guardrails.run_guardrails({}, "hello", "text/plain", configured, suppress_tripwire=True)
+    assert len(results) == 1
+    assert results[0].tripwire_triggered
+    assert results[0].info["guardrail_name"] == "Keyword Filter"
+
+
+@pytest.mark.parametrize("config,code", [(pipeline("output", "hello"), 0), ({}, 1), (pipeline("output", ""), 1)])
+def test_cli_validates_real_configuration(tmp_path: Path, capsys: pytest.CaptureFixture[str], config: dict[str, Any], code: int) -> None:
+    from guardrails.cli import main
+
+    path = tmp_path / "pipeline.json"
+    path.write_text(json.dumps(config))
+    with pytest.raises(SystemExit) as exc:
+        main(["validate", str(path), "--media-type", "text/plain"])
+    assert exc.value.code == code
+    output = capsys.readouterr()
+    if code == 0:
+        assert "1 guardrails loaded, 1 matching" in output.out
+    else:
+        assert "ERROR:" in output.err
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_case", CLIENTS, indirect=True)
+@pytest.mark.parametrize("api", ["chat", "responses"])
+@pytest.mark.xfail(
+    strict=True, raises=AssertionError, reason="Preexisting: streaming discards output guardrail results, including suppressed tripwires"
+)
+async def test_stream_exposes_suppressed_output_violation(client_case: Any, api: str) -> None:
+    make, _, asynchronous, _ = client_case
+    stream = await invoke(make(pipeline("output", "hello")), asynchronous, api, stream=True, suppress_tripwire=True)
+    chunks = [chunk async for chunk in stream] if asynchronous else await asyncio.to_thread(list, stream)
+    assert any(chunk.guardrail_results.tripwires_triggered for chunk in chunks)
+
+
+class CustomContext(BaseModel):
+    """Application context for a registered custom check."""
+
+    prefix: str
+
+
+class CustomConfig(BaseModel):
+    """Configuration consumed by the registered custom check."""
+
+    suffix: str
+
+
+def custom_sync(ctx: CustomContext, data: str, config: CustomConfig) -> guardrails.GuardrailResult:
+    import threading
+
+    return guardrails.GuardrailResult(tripwire_triggered=False, info={"value": ctx.prefix + data + config.suffix, "thread": threading.get_ident()})
+
+
+async def custom_async(ctx: CustomContext, data: str, config: CustomConfig) -> guardrails.GuardrailResult:
+    return custom_sync(ctx, data, config)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("check", [custom_sync, custom_async])
+async def test_custom_registry_to_execution(check: Any) -> None:
+    from guardrails.registry import GuardrailRegistry
+
+    registry = GuardrailRegistry()
+    registry.register(name="custom", check_fn=check, description="Custom check", media_type="text/plain")
+    bundle = guardrails.load_config_bundle({"guardrails": [{"name": "custom", "config": {"suffix": "!"}}]})
+    configured = guardrails.instantiate_guardrails(bundle, registry)
+    results = await guardrails.run_guardrails(CustomContext(prefix="say "), "hello", "text/plain", configured)
+    assert len(results) == 1
+    assert results[0].info["value"] == "say hello!"
+    assert not results[0].tripwire_triggered
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(strict=True, raises=AssertionError, reason="Preexisting: synchronous checks are invoked before asyncio.to_thread")
+async def test_sync_custom_check_runs_off_event_loop() -> None:
+    import threading
+
+    from guardrails.registry import GuardrailRegistry
+
+    registry = GuardrailRegistry()
+    registry.register(name="custom", check_fn=custom_sync, description="Custom check", media_type="text/plain")
+    configured = guardrails.instantiate_guardrails(
+        guardrails.load_config_bundle({"guardrails": [{"name": "custom", "config": {"suffix": "!"}}]}), registry
+    )
+    results = await guardrails.run_guardrails(CustomContext(prefix=""), "hello", "text/plain", configured)
+    assert results[0].info["thread"] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_case", CLIENTS, indirect=True)
+@pytest.mark.parametrize("api", ["chat", "responses"])
+async def test_provider_error_is_preserved(client_case: Any, api: str) -> None:
+    make, requests, asynchronous, _ = client_case
+    with pytest.raises(openai.RateLimitError) as exc:
+        await invoke(make(), asynchronous, api, extra_headers={"x-contract-error": "yes"})
+    assert exc.value.status_code == 429
+    assert len(requests) == 1

--- a/tests/integration/real_sdk/contract_cases.py
+++ b/tests/integration/real_sdk/contract_cases.py
@@ -20,7 +20,6 @@ import pytest_asyncio
 from pydantic import BaseModel
 
 import guardrails
-from guardrails import GuardrailsResponse, GuardrailTripwireTriggered
 from guardrails.context import GuardrailsContext, clear_context, set_context
 
 # Match the HTTP implementation used by the installed SDK (httpx or httpx2).
@@ -173,7 +172,7 @@ async def test_create_wire_contract(client_case: Any, api: str, stream: bool) ->
         assert (result.choices[0].delta.content if api == "chat" else result.delta) == "hello"
     else:
         assert (result.choices[0].message.content if api == "chat" else result.output_text) == "hello"
-    assert isinstance(result, GuardrailsResponse)
+    assert isinstance(result, guardrails.GuardrailsResponse)
     assert result.guardrail_results.all_results == []
     assert len(requests) == 1
     req = requests[0]
@@ -200,7 +199,7 @@ async def test_create_wire_contract(client_case: Any, api: str, stream: bool) ->
 async def test_actual_check_tripwire_and_suppression(client_case: Any, api: str, stage: str) -> None:
     make, requests, asynchronous, _ = client_case
     client = make(pipeline(stage, "hello"))
-    with pytest.raises(GuardrailTripwireTriggered):
+    with pytest.raises(guardrails.GuardrailTripwireTriggered):
         await invoke(client, asynchronous, api)
     assert len(requests) == (0 if stage == "pre_flight" else 1)
     result = await invoke(client, asynchronous, api, suppress_tripwire=True)
@@ -281,7 +280,7 @@ async def test_configuration_to_execution(tmp_path: Path, source_kind: str) -> N
     elif source_kind == "model":
         source = guardrails.load_config_bundle(bundle)
     configured = guardrails.instantiate_guardrails(guardrails.load_config_bundle(source))
-    with pytest.raises(GuardrailTripwireTriggered):
+    with pytest.raises(guardrails.GuardrailTripwireTriggered):
         await guardrails.run_guardrails({}, "hello", "text/plain", configured)
     results = await guardrails.run_guardrails({}, "hello", "text/plain", configured, suppress_tripwire=True)
     assert len(results) == 1

--- a/tests/integration/test_eval_contract.py
+++ b/tests/integration/test_eval_contract.py
@@ -1,0 +1,87 @@
+"""Exercise the public local-check evaluation workflow from JSONL to reports."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from guardrails.evals import GuardrailEval, JsonlDatasetLoader, validate_dataset
+
+
+@pytest.fixture
+def evaluation_files(tmp_path: Path) -> tuple[Path, Path]:
+    bundle = {"version": 1, "guardrails": [{"name": "Keyword Filter", "config": {"keywords": ["blocked"]}}]}
+    config = tmp_path / "config.json"
+    config.write_text(json.dumps({"version": 1, "pre_flight": bundle, "output": bundle}))
+    dataset = tmp_path / "samples.jsonl"
+    # One example in each confusion-matrix cell provides an independent oracle.
+    rows = [
+        {"id": "tp", "data": "blocked", "expected_triggers": {"Keyword Filter": True}},
+        {"id": "fp", "data": "blocked", "expected_triggers": {"Keyword Filter": False}},
+        {"id": "fn", "data": "allowed", "expected_triggers": {"Keyword Filter": True}},
+        {"id": "tn", "data": "allowed", "expected_triggers": {"Keyword Filter": False}},
+    ]
+    dataset.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+    return config, dataset
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stages", [None, ["output"]])
+async def test_evaluation_persists_correct_results_and_metrics(evaluation_files: tuple[Path, Path], tmp_path: Path, stages: list[str] | None) -> None:
+    config, dataset = evaluation_files
+    output = tmp_path / "reports"
+    evaluator = GuardrailEval(config, dataset, stages=stages, batch_size=2, output_dir=output, api_key="test-key")
+    await evaluator.run()
+
+    [run_dir] = list(output.iterdir())
+    metrics = json.loads((run_dir / "eval_metrics.json").read_text())
+    expected_stages = {"pre_flight", "output"} if stages is None else {"output"}
+    assert set(metrics) == expected_stages
+    for stage in expected_stages:
+        assert metrics[stage] == {
+            "Keyword Filter": {
+                "true_positives": 1,
+                "false_positives": 1,
+                "false_negatives": 1,
+                "true_negatives": 1,
+                "total_samples": 4,
+                "precision": 0.5,
+                "recall": 0.5,
+                "f1_score": 0.5,
+            }
+        }
+        rows = [json.loads(line) for line in (run_dir / f"eval_results_{stage}.jsonl").read_text().splitlines()]
+        assert len(rows) == 4
+        assert {row["id"]: row["triggered"]["Keyword Filter"] for row in rows} == {"tp": True, "fp": True, "fn": False, "tn": False}
+        assert {row["id"]: row["expected_triggers"]["Keyword Filter"] for row in rows} == {"tp": True, "fp": False, "fn": True, "tn": False}
+    assert "Total samples: 4" in (run_dir / "run_summary.txt").read_text()
+    assert {path.name for path in run_dir.glob("eval_results_*.jsonl")} == {f"eval_results_{stage}.jsonl" for stage in expected_stages}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["invalid_dataset", "unknown_check", "missing_stage"])
+async def test_invalid_evaluation_does_not_write_success_report(evaluation_files: tuple[Path, Path], tmp_path: Path, failure: str) -> None:
+    config, dataset = evaluation_files
+    options: dict[str, Any] = {}
+    if failure == "invalid_dataset":
+        dataset.write_text('{"id": "missing-required-fields"}\n')
+    elif failure == "unknown_check":
+        config.write_text(json.dumps({"output": {"guardrails": [{"name": "not-registered", "config": {}}]}}))
+    else:
+        options["stages"] = ["input"]
+    output = tmp_path / "reports"
+    evaluator = GuardrailEval(config, dataset, output_dir=output, api_key="test-key", **options)
+    with pytest.raises(ValueError):
+        await evaluator.run()
+    assert not output.exists()
+
+
+def test_dataset_validation_reports_line_and_loader_rejects_invalid_sample(tmp_path: Path) -> None:
+    path = tmp_path / "invalid.jsonl"
+    path.write_text('{"id":"ok","data":"text","expected_triggers":{}}\nnot json\n')
+    valid, messages = validate_dataset(path)
+    assert valid is False
+    assert any("Line 2" in message for message in messages)
+    with pytest.raises(ValueError, match="line 2"):
+        JsonlDatasetLoader().load(path)

--- a/tests/integration/test_real_sdk_contract.py
+++ b/tests/integration/test_real_sdk_contract.py
@@ -1,0 +1,23 @@
+"""Run real SDK contracts outside the suite's global OpenAI module stubs."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_real_sdk_contracts() -> None:
+    cases = Path(__file__).parent / "real_sdk" / "contract_cases.py"
+    # A fresh interpreter and confcutdir exclude tests/conftest.py's sys.modules
+    # replacement. Explicit transport mocks plus a socket guard prohibit traffic.
+    env = {key: value for key, value in os.environ.items() if not key.startswith(("OPENAI_", "AZURE_")) and "proxy" not in key.lower()}
+    env.pop("PYTEST_ADDOPTS", None)
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-ra", f"--confcutdir={cases.parent}", str(cases)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
This pull request adds isolated real-SDK contract tests and a local-check evaluation workflow from JSONL input to persisted results and metrics. The existing suite replaces the OpenAI SDK with stubs; the new subprocess lane exercises actual SDK request construction and response decoding using in-memory transports and no live provider calls.

Coverage includes all four client variants, Chat Completions and Responses, streaming, parsing, retrieval, public exports, configuration, custom checks, CLI validation and provider errors. Evaluation tests verify stage selection, persisted predictions, independently calculated metrics and failure without success reports. Public runtime behavior is unchanged.

Nine strict expected failures document two preexisting defects: streaming discards output guardrail results, and synchronous custom checks execute on the event-loop thread. The same contract cases produced identical results on the current code, the pre-restart baseline, and v0.3.2.

### Validation

- Formatting, Ruff, mypy and pyright passed.
- Full suite: 1,437 passed; the isolated SDK lane contains 79 passing cases and 9 strict expected failures.
- Six dataset-to-report evaluation cases passed on all three baselines.
- Two consecutive independent review rounds passed on the final patch.
