### PR TITLE
fix: Preserve full coverage of overlapping PII detections

### DIFF
--- a/src/guardrails/utils/anonymizer.py
+++ b/src/guardrails/utils/anonymizer.py
@@ -49,47 +49,43 @@ class AnonymizeResult:
     text: str
 
 
-def _resolve_overlaps(results: Sequence[RecognizerResult]) -> list[RecognizerResult]:
-    """Remove overlapping entity spans, keeping longer/earlier ones.
+@dataclass(slots=True)
+class _AnonymizationSpan:
+    """A replacement span owned by the anonymizer, independent of detections."""
 
-    When entities overlap, prioritize:
-    1. Longer spans over shorter ones
-    2. Earlier positions when spans are equal length
+    start: int
+    end: int
+    entity_type: str
+
+
+def _resolve_overlaps(results: Sequence[RecognizerResult]) -> list[RecognizerResult]:
+    """Merge overlapping spans without losing any detected text coverage.
+
+    Use the longest original detection's entity type for each connected group,
+    preferring the earlier detection for equal lengths. Adjacent spans remain
+    separate, and the analyzer's results are never mutated.
 
     Args:
         results: Sequence of recognizer results to resolve.
 
     Returns:
-        List of non-overlapping recognizer results.
-
-    Examples:
-        >>> # If EMAIL_ADDRESS spans (0, 20) and PERSON spans (5, 10), keep EMAIL_ADDRESS
-        >>> # If two entities span (0, 10) and (5, 15), keep the one starting at 0
+        Non-overlapping replacement spans covering every detection.
     """
-    if not results:
-        return []
+    merged: list[RecognizerResult] = []
+    preferred: RecognizerResult | None = None
+    for result in sorted(results, key=lambda r: r.start):
+        if not merged or result.start >= merged[-1].end:
+            merged.append(_AnonymizationSpan(result.start, result.end, result.entity_type))
+            preferred = result
+            continue
 
-    # Sort by: 1) longer spans first, 2) earlier position for equal lengths
-    sorted_results = sorted(
-        results,
-        key=lambda r: (-(r.end - r.start), r.start),
-    )
+        current = merged[-1]
+        current.end = max(current.end, result.end)
+        if preferred is not None and result.end - result.start > preferred.end - preferred.start:
+            current.entity_type = result.entity_type
+            preferred = result
 
-    # Filter out overlapping spans
-    non_overlapping: list[RecognizerResult] = []
-    for result in sorted_results:
-        # Check if this result overlaps with any already selected
-        overlaps = False
-        for selected in non_overlapping:
-            # Two spans overlap if one starts before the other ends
-            if result.start < selected.end and result.end > selected.start:
-                overlaps = True
-                break
-
-        if not overlaps:
-            non_overlapping.append(result)
-
-    return non_overlapping
+    return merged
 
 
 def anonymize(

--- a/tests/unit/checks/test_anonymizer_overlaps.py
+++ b/tests/unit/checks/test_anonymizer_overlaps.py
@@ -1,0 +1,48 @@
+"""Regression coverage for overlapping PII detections."""
+
+from __future__ import annotations
+
+import pytest
+from presidio_analyzer import RecognizerResult
+
+from guardrails.checks.text.pii import PIIConfig, PIIEntity, _get_analyzer_engine, pii
+from guardrails.utils.anonymizer import OperatorConfig, anonymize
+
+
+@pytest.mark.asyncio
+async def test_real_overlapping_detections_are_fully_masked() -> None:
+    """Presidio's email and URL recognizers can return partially overlapping spans."""
+    text = "Contact: jane@example.com/profile. End."
+    entities = [PIIEntity.EMAIL_ADDRESS, PIIEntity.URL]
+    config = PIIConfig(entities=entities, block=False)
+    detections = _get_analyzer_engine().analyze(text, entities=[entity.value for entity in entities], language="en")
+    assert {(r.entity_type, r.start, r.end) for r in detections} == {("EMAIL_ADDRESS", 9, 25), ("URL", 14, 34)}
+
+    result = await pii(None, text, config)
+
+    assert result.info["checked_text"] == "Contact: <URL> End."
+    assert result.tripwire_triggered is False
+    assert set(result.info["detected_entities"]) == {"EMAIL_ADDRESS", "URL"}
+
+
+@pytest.mark.parametrize(
+    ("spans", "expected"),
+    [
+        ([], "abcdefghijklmnop"),
+        ([(0, 4, "A"), (4, 8, "B")], "<A><B>ijklmnop"),
+        ([(0, 8, "A"), (2, 4, "B")], "<A>ijklmnop"),
+        ([(0, 6, "A"), (4, 10, "B")], "<A>klmnop"),
+        ([(0, 6, "A"), (4, 10, "B"), (9, 16, "C")], "<C>"),
+        ([(0, 7, "A"), (5, 10, "B"), (9, 16, "C")], "<A>"),
+    ],
+    ids=["empty", "adjacent", "contained", "partial", "transitive-longest-original", "transitive-earliest-tie"],
+)
+def test_overlap_coverage_and_precedence(spans: list[tuple[int, int, str]], expected: str) -> None:
+    """Cover connected detections while preserving marker precedence and input spans."""
+    detections = [RecognizerResult(entity_type=entity, start=start, end=end, score=1.0) for start, end, entity in spans]
+    operators = {entity: OperatorConfig("replace", {"new_value": f"<{entity}>"}) for _, _, entity in spans}
+
+    for ordered in (detections, list(reversed(detections))):
+        result = anonymize("abcdefghijklmnop", ordered, operators)
+        assert result.text == expected
+        assert [(r.start, r.end, r.entity_type) for r in detections] == spans

--- a/tests/unit/test_structured_pii_masking.py
+++ b/tests/unit/test_structured_pii_masking.py
@@ -6,7 +6,7 @@ import asyncio
 import base64
 import urllib.parse
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -114,3 +114,39 @@ def test_url_offsets_match_standard_library_prefix_decoding(text: str) -> None:
     from guardrails.checks.text.pii import _url_decoded_offsets
 
     assert _url_decoded_offsets(text) == [len(urllib.parse.unquote(text[:end])) for end in range(len(text) + 1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("responses", [False, True])
+async def test_overlapping_pii_is_masked_in_structured_content(asynchronous: bool, responses: bool) -> None:
+    """Real overlapping recognizers must not expose text in provider-bound parts."""
+    config = {
+        "version": 1,
+        "pre_flight": {
+            "version": 1,
+            "guardrails": [{"name": "Contains PII", "config": {"entities": ["EMAIL_ADDRESS", "URL"], "block": False}}],
+        },
+    }
+    text_type = "input_text" if responses else "text"
+    messages: Any = [{"role": "user", "content": [{"type": text_type, "text": "Contact: jane@example.com/profile. End."}]}]
+    response = SimpleNamespace(output=[], output_text="OK", choices=[SimpleNamespace(message=SimpleNamespace(content="OK"))])
+    client = GuardrailsAsyncOpenAI(config=config, api_key="test-key") if asynchronous else GuardrailsOpenAI(config=config, api_key="test-key")
+    provider = AsyncMock(return_value=response) if asynchronous else Mock(return_value=response)
+    if responses:
+        client._resource_client.responses = SimpleNamespace(create=provider)
+        resource = cast(Any, client.responses)
+        kwargs = {"input": messages, "model": "test-model"}
+    else:
+        client._resource_client.chat = SimpleNamespace(completions=SimpleNamespace(create=provider))
+        resource = client.chat.completions
+        kwargs = {"messages": messages, "model": "test-model"}
+    if asynchronous:
+        await resource.create(**kwargs)
+    else:
+        await asyncio.to_thread(lambda: resource.create(**kwargs))
+
+    provider.assert_called_once()
+    forwarded = provider.call_args.kwargs["input" if responses else "messages"]
+    assert forwarded[0]["content"] == [{"type": text_type, "text": "Contact: <URL> End."}]
+    assert messages[0]["content"][0]["text"] == "Contact: jane@example.com/profile. End."


### PR DESCRIPTION
## Summary

This pull request fixes incomplete PII masking when Presidio returns partially overlapping detections. An email followed by a URL path can produce overlapping email and URL spans; selecting only one span leaves part of the detected email visible.

Merge connected spans so masking covers every detected character, selecting the placeholder from the longest original detection and preferring the earlier detection on ties. Keep adjacent spans separate and leave analyzer results unchanged. The shared anonymizer covers plain text and structured content without changing public APIs or blocking behavior.

## Validation

- Real Presidio regression and sync/async Chat Completions and Responses structured-content coverage.
- Formatting, Ruff, mypy, and pyright passed.
- Full suite: 1,448 tests passed.
- Two independent pre-submission review rounds completed without blocking findings.
