### PR TITLE
fix: Preserve masked conversation history in output checks

### DIFF
--- a/src/guardrails/resources/chat/chat.py
+++ b/src/guardrails/resources/chat/chat.py
@@ -85,6 +85,8 @@ class ChatCompletions:
 
         # Apply pre-flight modifications (PII masking, etc.)
         modified_messages = self._client._apply_preflight_modifications(messages, preflight_results)
+        # Output checks must see the same sanitized input as the provider.
+        output_conversation = self._client._normalize_conversation(modified_messages)
 
         # Run input guardrails and LLM call concurrently using a thread for the LLM
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -116,7 +118,7 @@ class ChatCompletions:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
         else:
@@ -124,7 +126,7 @@ class ChatCompletions:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
 
@@ -157,6 +159,8 @@ class AsyncChatCompletions:
 
         # Apply pre-flight modifications (PII masking, etc.)
         modified_messages = self._client._apply_preflight_modifications(messages, preflight_results)
+        # Output checks must see the same sanitized input as the provider.
+        output_conversation = self._client._normalize_conversation(modified_messages)
 
         # Run input guardrails and LLM call concurrently for both streaming and non-streaming
         input_check = self._client._run_stage_guardrails(
@@ -184,7 +188,7 @@ class AsyncChatCompletions:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
         else:
@@ -192,6 +196,6 @@ class AsyncChatCompletions:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )

--- a/src/guardrails/resources/responses/responses.py
+++ b/src/guardrails/resources/responses/responses.py
@@ -66,6 +66,9 @@ class Responses:
 
         # Apply pre-flight modifications (PII masking, etc.)
         modified_input = self._client._apply_preflight_modifications(input, preflight_results)
+        # Output checks must see the same sanitized input as the provider.
+        output_conversation = [entry.copy() for entry in prior_history]
+        output_conversation.extend(self._client._normalize_conversation(modified_input))
 
         # Input guardrails and LLM call concurrently
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -98,7 +101,7 @@ class Responses:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
         else:
@@ -106,7 +109,7 @@ class Responses:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
 
@@ -133,6 +136,9 @@ class Responses:
 
         # Apply pre-flight modifications (PII masking, etc.)
         modified_input = self._client._apply_preflight_modifications(input, preflight_results)
+        # Output checks must see the same sanitized input as the provider.
+        output_conversation = [entry.copy() for entry in prior_history]
+        output_conversation.extend(self._client._normalize_conversation(modified_input))
 
         # Input guardrails and LLM call concurrently
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -162,7 +168,7 @@ class Responses:
             llm_response,
             preflight_results,
             input_results,
-            conversation_history=normalized_conversation,
+            conversation_history=output_conversation,
             suppress_tripwire=suppress_tripwire,
         )
 
@@ -230,6 +236,9 @@ class AsyncResponses:
 
         # Apply pre-flight modifications (PII masking, etc.)
         modified_input = self._client._apply_preflight_modifications(input, preflight_results)
+        # Output checks must see the same sanitized input as the provider.
+        output_conversation = [entry.copy() for entry in prior_history]
+        output_conversation.extend(self._client._normalize_conversation(modified_input))
 
         # Run input guardrails and LLM call in parallel
         input_check = self._client._run_stage_guardrails(
@@ -259,7 +268,7 @@ class AsyncResponses:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
         else:
@@ -267,7 +276,7 @@ class AsyncResponses:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
 
@@ -296,6 +305,9 @@ class AsyncResponses:
 
         # Apply pre-flight modifications (PII masking, etc.)
         modified_input = self._client._apply_preflight_modifications(input, preflight_results)
+        # Output checks must see the same sanitized input as the provider.
+        output_conversation = [entry.copy() for entry in prior_history]
+        output_conversation.extend(self._client._normalize_conversation(modified_input))
 
         # Run input guardrails and LLM call in parallel
         input_check = self._client._run_stage_guardrails(
@@ -325,7 +337,7 @@ class AsyncResponses:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
         else:
@@ -333,7 +345,7 @@ class AsyncResponses:
                 llm_response,
                 preflight_results,
                 input_results,
-                conversation_history=normalized_conversation,
+                conversation_history=output_conversation,
                 suppress_tripwire=suppress_tripwire,
             )
 

--- a/tests/unit/test_masked_output_history.py
+++ b/tests/unit/test_masked_output_history.py
@@ -1,0 +1,118 @@
+"""Output classifiers consume the same masked current input as the provider."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest import TestCase
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from pydantic import BaseModel
+
+from guardrails.checks.text.llm_base import LLMOutput, run_llm
+from guardrails.client import GuardrailsAsyncOpenAI, GuardrailsOpenAI
+from guardrails.types import GuardrailResult
+
+
+class _ParsedReply(BaseModel):
+    answer: str
+
+
+@pytest.mark.parametrize("client_type", [GuardrailsOpenAI, GuardrailsAsyncOpenAI])
+@pytest.mark.parametrize("api,stream", [("chat", False), ("chat", True), ("responses", False), ("responses", True), ("parse", False)])
+@pytest.mark.parametrize("mask", [True, False])
+def test_output_classifier_receives_provider_input(monkeypatch: pytest.MonkeyPatch, client_type: Any, api: str, stream: bool, mask: bool) -> None:
+    """Preserve masking through actual resource, response, and classifier pipelines."""
+    import asyncio
+
+    check = TestCase()
+    is_async = client_type is GuardrailsAsyncOpenAI
+    client = client_type(config={"version": 1, "output": {"version": 1, "guardrails": []}}, api_key="test-key")
+    guardrail = SimpleNamespace(definition=SimpleNamespace(metadata=SimpleNamespace(uses_conversation_history=True)))
+    client.guardrails = {stage: [guardrail] for stage in ("pre_flight", "input", "output")}
+    original = "Please contact sample@example.test"
+    sanitized = "Please contact <EMAIL_ADDRESS>" if mask else original
+    prior = [{"role": "assistant", "content": "Earlier reply"}]
+    messages = [{"role": "system", "content": "Be helpful"}, {"role": "user", "content": original}]
+    # Exercise Responses string input and structured parse input separately.
+    payload = original if api == "responses" else messages
+    untouched = deepcopy(payload)
+    prior_snapshot = deepcopy(prior)
+    classifier = AsyncMock(
+        return_value=SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content='{"flagged": false, "confidence": 0.0}'))], usage=None)
+    )
+    monkeypatch.setattr("guardrails.checks.text.llm_base._request_chat_completion", classifier)
+    stage_history: dict[str, Any] = {}
+
+    async def run_checks(**kwargs: Any) -> list[GuardrailResult]:
+        stage = kwargs["stage_name"]
+        history = kwargs["ctx"].get_conversation_history()
+        stage_history[stage] = deepcopy(history)
+        if stage == "pre_flight":
+            return [
+                GuardrailResult(tripwire_triggered=False, info={"guardrail_name": "Contains PII", "pii_detected": mask, "checked_text": sanitized})
+            ]
+        if stage == "output":
+            await run_llm(
+                kwargs["data"], "Classify the conversation", client.context.guardrail_llm, "test-model", LLMOutput, conversation_history=history
+            )
+        return []
+
+    monkeypatch.setattr("guardrails.client.run_guardrails", run_checks)
+    reply = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(role="assistant", content="Reply"))], output=None, output_text="Reply")
+    chunk = SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="Reply"))])
+
+    async def chunks() -> AsyncIterator[Any]:
+        yield chunk
+
+    provider_result = (chunks() if is_async else iter([chunk])) if stream else reply
+    provider = AsyncMock(return_value=provider_result) if is_async else Mock(return_value=provider_result)
+    if api == "chat":
+        client._resource_client.chat = SimpleNamespace(completions=SimpleNamespace(create=provider))
+        call = client.chat.completions.create
+        arguments = {"messages": payload, "model": "test-model", "stream": stream}
+        expected_history = [{"role": "system", "content": "Be helpful"}, {"role": "user", "content": sanitized}]
+    else:
+        client._resource_client.responses = SimpleNamespace(create=provider, parse=provider)
+        loader = AsyncMock(return_value=prior) if is_async else Mock(return_value=prior)
+        monkeypatch.setattr(client, "_load_conversation_history_from_previous_response", loader)
+        call = client.responses.parse if api == "parse" else client.responses.create
+        arguments = {"input": payload, "model": "test-model", "previous_response_id": "previous"}
+        if api == "parse":
+            arguments["text_format"] = cast(Any, _ParsedReply)
+        else:
+            arguments["stream"] = stream
+        expected_history = (
+            prior + ([{"role": "system", "content": "Be helpful"}] if api == "parse" else []) + [{"role": "user", "content": sanitized}]
+        )
+
+    async def invoke_async() -> None:
+        result = await call(**arguments)
+        if stream:
+            async for _ in result:
+                pass
+
+    if is_async:
+        asyncio.run(invoke_async())
+    else:
+        result = call(**arguments)
+        if stream:
+            list(result)
+
+    expected_provider = sanitized if api == "responses" else [{"role": "system", "content": "Be helpful"}, {"role": "user", "content": sanitized}]
+    check.assertEqual(provider.call_args.kwargs["messages" if api == "chat" else "input"], expected_provider)
+    check.assertEqual(payload, untouched)
+    check.assertEqual(prior, prior_snapshot)
+    check.assertEqual(stage_history["pre_flight"][-1]["content"], original)
+    check.assertEqual(stage_history["input"][-1]["content"], original)
+    check.assertEqual(stage_history["output"], expected_history + [{"role": "assistant", "content": "Reply"}])
+    classifier.assert_awaited_once()
+    user_content = classifier.call_args.kwargs["messages"][1]["content"]
+    analysis = json.loads(user_content.split("\n\n", 1)[1])
+    check.assertEqual(analysis["conversation"], expected_history + [{"role": "assistant", "content": "Reply"}])
+    if mask:
+        check.assertNotIn(original, user_content)

--- a/tests/unit/test_resources_responses.py
+++ b/tests/unit/test_resources_responses.py
@@ -311,7 +311,7 @@ def test_responses_create_stream_returns_stream(monkeypatch: pytest.MonkeyPatch)
     stream_call = client.stream_calls[0]
     assert stream_call["suppress"] is True  # noqa: S101
     assert stream_call["preflight"] == ["preflight"]  # noqa: S101
-    assert stream_call["history"] == normalize_conversation(_messages())  # noqa: S101
+    assert stream_call["history"] == [{"role": "user", "content": "modified"}]  # noqa: S101
 
 
 def test_responses_create_merges_previous_history(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -349,7 +349,7 @@ def test_responses_parse_runs_guardrails(monkeypatch: pytest.MonkeyPatch) -> Non
 
     assert result == "handled"  # noqa: S101
     assert client.parse_calls[0]["input"][0]["content"] == "modified"  # noqa: S101
-    assert client.handle_calls[0]["history"] == normalize_conversation(messages)  # noqa: S101
+    assert client.handle_calls[0]["history"] == [{"role": "user", "content": "modified"}]  # noqa: S101
 
 
 def test_responses_parse_merges_previous_history(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -418,7 +418,7 @@ async def test_async_responses_stream_returns_wrapper() -> None:
     stream_call = client.stream_calls[0]
     assert stream_call["preflight"] == ["preflight"]  # noqa: S101
     assert stream_call["input"] == ["input"]  # noqa: S101
-    assert stream_call["history"] == normalize_conversation(_messages())  # noqa: S101
+    assert stream_call["history"] == [{"role": "user", "content": "modified"}]  # noqa: S101
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request fixes output classifiers receiving original conversation text after successful preflight masking. Chat Completions and Responses output checks now use normalized masked provider input across sync/async, streaming, and structured-response paths, preserving loaded Responses history and existing input-stage behavior without changing public APIs.

Validation: formatting, lint, mypy, pyright, and all 1,457 tests pass. Regression tests exercise public resource-to-classifier paths; all 10 masking cases fail on v0.3.3 and pass with this change, while unchanged-input controls pass.
