### PR TITLE
fix: Bound Secret Keys file-container matching

### DIFF
--- a/src/guardrails/checks/text/secret_keys.py
+++ b/src/guardrails/checks/text/secret_keys.py
@@ -109,8 +109,8 @@ _EXPLICIT_URL_SCHEME_RE = re.compile(
     r"(?:https?|ftp)://|(?:data|javascript|vbscript):",
     re.IGNORECASE,
 )
-_URL_SHAPED_SCHEME_RE = re.compile(
-    r"[a-z][a-z0-9+.-]*:/",
+_URL_SCHEME_SPAN_RE = re.compile(
+    r"[a-z][a-z0-9+.-]*",
     re.IGNORECASE,
 )
 _ASCII_SCHEME_START_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -638,7 +638,9 @@ def _iter_exempt_container_candidates(text: str) -> Iterator[str]:
         file_text = prefix.strip("".join(_ADJACENT_SCHEME_URL_BOUNDARIES))
 
     file_text = file_text.strip("*#")
-    if _URL_SHAPED_SCHEME_RE.search(file_text) is not None:
+    # Consume each maximal scheme span once; a failing delimiter in the regex
+    # would retry overlapping suffixes of long filenames.
+    if any(file_text.startswith(":/", match.end()) for match in _URL_SCHEME_SPAN_RE.finditer(file_text)):
         return
     lowered = file_text.lower()
     for extension in ALLOWED_EXTENSIONS:

--- a/tests/unit/checks/test_secret_keys.py
+++ b/tests/unit/checks/test_secret_keys.py
@@ -1202,6 +1202,32 @@ async def test_double_slash_prefixed_http_url_does_not_expose_query_candidates()
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("prefix", "detected"),
+    [
+        ("archive/release-notes/", True),
+        ("archive/a1+.-/", True),
+        ("archive/123:/", True),
+        ("archive/a:notes/", True),
+        ("archive/a:/", False),
+        ("archive/1a+.-:/", False),
+        ("archive/a:notes/b:/", False),
+        ("archive/İ:/", False),
+        ("archive/ı:/", False),
+        ("archive/ſ:/", False),
+        ("archive/K:/", False),
+    ],
+)
+async def test_file_container_scheme_classification(prefix: str, detected: bool) -> None:
+    """File basenames remain detectable unless a URL-shaped scheme precedes them."""
+    text = f"{prefix}sk-AAAABBBBCCCCDDDD.png"
+    result = await secret_keys(None, text, SecretKeysCfg(threshold="balanced", custom_regex=None))
+
+    assert result.tripwire_triggered is detected
+    assert result.info["detected_secrets"] == ([text] if detected else [])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "text",
     [
         "files/prefixhttps://example.com/sk-AAAABBBBCCCCDDDD.png",


### PR DESCRIPTION
This pull request fixes repeated suffix scanning during Secret Keys file-container classification by consuming each scheme-like span once and checking its following delimiter separately. It preserves released file and URL classification, including case-insensitive Unicode matching, without changing public APIs or extension handling.

Validation: all 1,448 tests passed, along with formatting, lint, mypy, and pyright. Added public-boundary regression coverage for file paths, scheme delimiters, numeric prefixes, multiple spans, and Unicode classification.
