### PR TITLE
docs: Tighten README and verify setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,224 +1,170 @@
 # OpenAI Guardrails: Python (Preview)
 
-This is the Python version of OpenAI Guardrails, a package for adding configurable safety and compliance guardrails to LLM applications. It provides a drop-in wrapper for OpenAI's Python client, enabling automatic input/output validation and moderation using a wide range of guardrails.
+Add configurable safety and compliance checks to LLM applications. OpenAI Guardrails wraps the OpenAI Python client to validate inputs and outputs, and integrates with the OpenAI Agents SDK.
 
-Most users can simply follow the guided configuration and installation instructions at [guardrails.openai.com](https://guardrails.openai.com/).
+[Configure guardrails](https://guardrails.openai.com/) · [Documentation](https://openai.github.io/openai-guardrails-python/) · [Examples](./examples)
 
-[![OpenAI Guardrails configuration screenshot](https://github.com/openai/openai-guardrails-python/blob/main/docs/assets/images/guardrails-python-config-screenshot-100pct-q70.webp?raw=1)](https://guardrails.openai.com)
+[![OpenAI Guardrails configuration screenshot](https://raw.githubusercontent.com/openai/openai-guardrails-python/main/docs/assets/images/guardrails-python-config-screenshot-100pct-q70.webp)](https://guardrails.openai.com/)
 
 ## Installation
 
-You can download [openai-guardrails package](https://pypi.org/project/openai-guardrails/) this way:
+Requires **Python 3.11+**. Install [openai-guardrails](https://pypi.org/project/openai-guardrails/):
 
 ```bash
 pip install openai-guardrails
 ```
 
-If you enable Contains PII, install its spaCy model while building or deploying the application:
+If your configuration uses **Contains PII**, also install its spaCy model during build or deployment:
 
 ```bash
-# With pip
 python -m spacy download en_core_web_sm
+```
 
-# With uv and spaCy 3.8
+For uv with spaCy 3.8, install the model wheel directly:
+
+```bash
 uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
 ```
 
-Contains PII validates and loads this model during client initialization, so an absent or unloadable model fails configuration before any request.
+Contains PII validates and loads this model during client initialization; a missing or unloadable model fails configuration before any request. See the [Contains PII guide](https://openai.github.io/openai-guardrails-python/ref/checks/pii/) for configuration options.
 
-### Usage
+## Quickstart
 
-Follow the configuration and installation instructions at [guardrails.openai.com](https://guardrails.openai.com/).
-
-### Local Development
-
-Clone the repository and install locally:
-
-```bash
-# Clone the repository
-git clone https://github.com/openai/openai-guardrails-python.git
-cd openai-guardrails-python
-
-# Install the package (editable), plus example extras if desired
-pip install -e .
-pip install -e ".[examples]"
-pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
-```
-
-## Integration Details
-
-### Drop-in OpenAI Replacement
-
-The easiest way to use Guardrails Python is as a drop-in replacement for the OpenAI client:
+1. Create and export a pipeline configuration with the [Guardrails wizard](https://guardrails.openai.com/). Save it as `guardrails_config.json` in your working directory.
+2. Set the `OPENAI_API_KEY` environment variable to your OpenAI API key.
+3. Use `GuardrailsOpenAI` in place of `OpenAI`:
 
 ```python
 from pathlib import Path
+
 from guardrails import GuardrailsOpenAI, GuardrailTripwireTriggered
 
-# Use GuardrailsOpenAI instead of OpenAI
-client = GuardrailsOpenAI(config=Path("guardrail_config.json"))
+client = GuardrailsOpenAI(config=Path("guardrails_config.json"))
 
 try:
-    # Works with standard Chat Completions
+    # Chat Completions API
     chat = client.chat.completions.create(
         model="gpt-5",
         messages=[{"role": "user", "content": "Hello world"}],
     )
     print(chat.choices[0].message.content)
 
-    # Or with the Responses API
-    resp = client.responses.create(
+    # Responses API
+    response = client.responses.create(
         model="gpt-5",
         input="What are the main features of your premium plan?",
     )
-    print(resp.output_text)
-except GuardrailTripwireTriggered as e:
-    print(f"Guardrail triggered: {e}")
+    print(response.output_text)
+except GuardrailTripwireTriggered:
+    print("Message blocked by guardrails.")
 ```
 
-### Agents SDK Integration
+For async and Azure clients, see the [quickstart guide](https://openai.github.io/openai-guardrails-python/quickstart/). Read about [tripwire handling](https://openai.github.io/openai-guardrails-python/tripwires/) and [streaming behavior](https://openai.github.io/openai-guardrails-python/streaming_output/) before integrating those flows.
 
-You can integrate guardrails with the OpenAI Agents SDK via `GuardrailAgent`:
+### Agents SDK
+
+Use `GuardrailAgent` with the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/). This example uses the same config file and API key as the quickstart:
 
 ```python
 import asyncio
 from pathlib import Path
+
 from agents import InputGuardrailTripwireTriggered, OutputGuardrailTripwireTriggered, Runner
 from agents.run import RunConfig
+
 from guardrails import GuardrailAgent
 
-# Create agent with guardrails automatically configured
 agent = GuardrailAgent(
     config=Path("guardrails_config.json"),
     name="Customer support agent",
-    instructions="You are a customer support agent. You help customers with their questions.",
+    instructions="You help customers with their questions.",
 )
+
 
 async def main():
     try:
-        result = await Runner.run(agent, "Hello, can you help me?", run_config=RunConfig(tracing_disabled=True))
+        result = await Runner.run(
+            agent, "Hello, can you help me?", run_config=RunConfig(tracing_disabled=True)
+        )
         print(result.final_output)
     except (InputGuardrailTripwireTriggered, OutputGuardrailTripwireTriggered):
-        print("🛑 Guardrail triggered!")
+        print("Message blocked by guardrails.")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-> For more details, see [`docs/agents_sdk_integration.md`](./docs/agents_sdk_integration.md).
+See the [Agents SDK integration guide](https://openai.github.io/openai-guardrails-python/agents_sdk_integration/) for configuration and tool guardrails.
 
-## Evaluation Framework
+## Evaluations
 
-Evaluate guardrail performance on labeled datasets and run benchmarks.
-
-### Running Evaluations
+Measure guardrail performance on labeled datasets using the same exported configuration. Install the evaluation dependencies first (currently required for basic evaluation as well as benchmarking):
 
 ```bash
-# Basic evaluation
+pip install "openai-guardrails[benchmark]"
 python -m guardrails.evals.guardrail_evals \
   --config-path guardrails_config.json \
   --dataset-path data.jsonl
-
-# Benchmark mode (compare models, generate ROC curves, latency)
-python -m guardrails.evals.guardrail_evals \
-  --config-path guardrails_config.json \
-  --dataset-path data.jsonl \
-  --mode benchmark \
-  --models gpt-5 gpt-5-mini gpt-4.1-mini
 ```
 
-### Dataset Format
-
-Datasets must be in JSONL format, with each line containing a JSON object:
+Save one JSON object per line in `data.jsonl`, with labels for the guardrails in your configuration. For a configuration containing Moderation and NSFW Text:
 
 ```json
-{
-  "id": "sample_1",
-  "data": "Text or conversation to evaluate",
-  "expected_triggers": {
-    "Moderation": true,
-    "NSFW Text": false
-  }
-}
+{"id": "sample_1", "data": "Hello world", "expected_triggers": {"Moderation": false, "NSFW Text": false}}
 ```
 
-### Programmatic Usage
+For the programmatic API, model comparisons, benchmark dependencies, and dataset options, see the [evaluation guide](https://openai.github.io/openai-guardrails-python/evals/).
 
-```python
-from pathlib import Path
-from guardrails.evals.guardrail_evals import GuardrailEval
+## Examples and Local Development
 
-eval = GuardrailEval(
-    config_path=Path("guardrails_config.json"),
-    dataset_path=Path("data.jsonl"),
-    batch_size=32,
-    output_dir=Path("results"),
-)
-
-import asyncio
-asyncio.run(eval.run())
-```
-
-### Project Structure
-
-- `src/guardrails/` - Python source code
-- `src/guardrails/checks/` - Built-in guardrail checks
-- `src/guardrails/evals/` - Evaluation framework
-- `examples/` - Example usage and sample configs
-
-## Examples
-
-The package includes examples in the [`examples/` directory](./examples):
-
-- `examples/basic/hello_world.py` — Basic chatbot with guardrails using `GuardrailsOpenAI`
-- `examples/basic/agents_sdk.py` — Agents SDK integration with `GuardrailAgent`
-- `examples/basic/local_model.py` — Using local models with guardrails
-- `examples/basic/structured_outputs_example.py` — Structured outputs
-- `examples/basic/pii_mask_example.py` — PII masking
-- `examples/basic/suppress_tripwire.py` — Handling violations gracefully
-
-### Running Examples
-
-#### Prerequisites
+Clone the repository and install it with the example dependencies:
 
 ```bash
-pip install -e .
-pip install "openai-guardrails[examples]"
-pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl
+git clone https://github.com/openai/openai-guardrails-python.git
+cd openai-guardrails-python
+pip install -e ".[examples]"
 ```
 
-#### Run
+Set `OPENAI_API_KEY` as above. Install the spaCy model from the installation section for examples that use Contains PII, including `agents_sdk.py`.
 
 ```bash
 python examples/basic/hello_world.py
 python examples/basic/agents_sdk.py
 ```
 
+Explore the examples:
+
+- [Basic chatbot](./examples/basic/hello_world.py) — async client with guardrails
+- [Agents SDK](./examples/basic/agents_sdk.py) — agent with input and output checks
+- [Local models](./examples/basic/local_model.py) — OpenAI-compatible model endpoints
+- [Structured outputs](./examples/basic/structured_outputs_example.py)
+- [PII masking](./examples/basic/pii_mask_example.py)
+- [Tripwire suppression](./examples/basic/suppress_tripwire.py)
+
 ## Available Guardrails
 
-The Python implementation includes the following built-in guardrails:
-
-- **Keyword Filter**: Detects configured banned keywords and phrases
-- **Competitors**: Detects mentions of configured competitors
-- **Moderation**: Content moderation using OpenAI's moderation API
-- **URL Filter**: URL filtering and domain allowlist/blocklist
-- **Secret Keys**: Detects potential API keys, secrets, and credentials
-- **Contains PII**: Personally Identifiable Information detection
-- **Hallucination Detection**: Detects hallucinated content using vector stores
-- **Jailbreak**: Detects jailbreak attempts
-- **Prompt Injection Detection**: Detects malicious instructions in tool calls and tool outputs
-- **NSFW Text**: Detects workplace-inappropriate content in model outputs
-- **Off Topic Prompts**: Ensures responses stay within business scope
-- **Custom Prompt Check**: Custom LLM-based guardrails
-
-For full details, advanced usage, and API reference, see: [OpenAI Guardrails Documentation](https://openai.github.io/openai-guardrails-python/).
+| Guardrail | Checks for |
+| --- | --- |
+| [Keyword Filter](https://openai.github.io/openai-guardrails-python/ref/checks/keywords/) | Configured keywords and phrases |
+| [Competitors](https://openai.github.io/openai-guardrails-python/ref/checks/competitors/) | Mentions of configured competitors |
+| [Moderation](https://openai.github.io/openai-guardrails-python/ref/checks/moderation/) | Content flagged by OpenAI's moderation API |
+| [URL Filter](https://openai.github.io/openai-guardrails-python/ref/checks/urls/) | URLs against domain allowlists or blocklists |
+| [Secret Keys](https://openai.github.io/openai-guardrails-python/ref/checks/secret_keys/) | Potential API keys, secrets, and credentials |
+| [Contains PII](https://openai.github.io/openai-guardrails-python/ref/checks/pii/) | Personally identifiable information |
+| [Hallucination Detection](https://openai.github.io/openai-guardrails-python/ref/checks/hallucination_detection/) | Claims against reference material in vector stores |
+| [Jailbreak](https://openai.github.io/openai-guardrails-python/ref/checks/jailbreak/) | Jailbreak attempts |
+| [Prompt Injection Detection](https://openai.github.io/openai-guardrails-python/ref/checks/prompt_injection_detection/) | Misaligned tool calls and tool outputs |
+| [NSFW Text](https://openai.github.io/openai-guardrails-python/ref/checks/nsfw/) | Workplace-inappropriate content |
+| [Off Topic Prompts](https://openai.github.io/openai-guardrails-python/ref/checks/off_topic_prompts/) | Content outside a configured topic or scope |
+| [Custom Prompt Check](https://openai.github.io/openai-guardrails-python/ref/checks/custom_prompt_check/) | Violations of custom instructions |
 
 ## License
 
-MIT License - see LICENSE file for details.
+[MIT](./LICENSE).
 
 ## Disclaimers
 
-Please note that Guardrails may use Third-Party Services such as the [Presidio open-source framework](https://github.com/microsoft/presidio), which are subject to their own terms and conditions and are not developed or verified by OpenAI.
+Guardrails may use Third-Party Services such as the [Presidio open-source framework](https://github.com/microsoft/presidio), which are subject to their own terms and conditions and are not developed or verified by OpenAI.
 
 Developers are responsible for implementing appropriate safeguards to prevent storage or misuse of sensitive or prohibited content (including but not limited to personal data, child sexual abuse material, or other illegal content). OpenAI disclaims liability for any logging or retention of such content by developers. Developers must ensure their systems comply with all applicable data protection and content safety laws, and should avoid persisting any blocked content generated or intercepted by Guardrails. Guardrails calls paid OpenAI APIs, and developers are responsible for associated charges.


### PR DESCRIPTION
## Summary

Improve the README with one setup flow, consistent config filenames, linked guides and examples, and a compact guardrail reference. Correct the JSONL sample and document the extras currently needed for evaluations; remove duplicated setup and detail covered by the guides.

## Validation

- Execute both Python snippets through the real clients and Agents runner with mocked HTTP responses, covering success and tripwire paths.
- Validate the JSONL sample with the real dataset loader and check evaluation CLI help, Python lint, and shell syntax.
- Check local and remote links, build documentation, and run `git diff --check`.
