### PR TITLE
chore: require SDK-team ownership for release files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Require SDK-team review for release workflows and ownership changes.
+/.github/ @openai/sdks-team
+
+# Package build configuration and release-please inputs and outputs.
+/Makefile @openai/sdks-team
+/pyproject.toml @openai/sdks-team
+/release-please-config.json @openai/sdks-team
+/.release-please-manifest.json @openai/sdks-team
+/CHANGELOG.md @openai/sdks-team


### PR DESCRIPTION
The repository requires code-owner review but has no CODEOWNERS file. Add @openai/sdks-team ownership for GitHub workflow and ownership configuration, package build configuration, and release-please configuration, version, and changelog files so release-related changes receive SDK-team review after this merges.

Validation: checked required path coverage, confirmed the team has repository write access and eligible visibility, and passed whitespace checks and two independent review rounds. This is a repository-metadata-only change.
